### PR TITLE
pr-read-in-memory

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -512,6 +512,12 @@ func OpenFile(filename string) (*File, error) {
 // xlsx.File struct populated with its contents.  In most cases
 // ReadZip is not used directly, but is called internally by OpenFile.
 func ReadZip(f *zip.ReadCloser) (*File, error) {
+	defer f.Close()
+	return ReadZipReader(&f.Reader)
+}
+
+// ReadZipReader() can be used to read xlsx in memory without touch filesystem.
+func ReadZipReader(r *zip.Reader) (*File, error) {
 	var err error
 	var file *File
 	var names []string
@@ -528,8 +534,8 @@ func ReadZip(f *zip.ReadCloser) (*File, error) {
 	var worksheets map[string]*zip.File
 
 	file = new(File)
-	worksheets = make(map[string]*zip.File, len(f.File))
-	for _, v = range f.File {
+	worksheets = make(map[string]*zip.File, len(r.File))
+	for _, v = range r.File {
 		switch v.Name {
 		case "xl/sharedStrings.xml":
 			sharedStrings = v
@@ -582,6 +588,5 @@ func ReadZip(f *zip.ReadCloser) (*File, error) {
 		sheetMap[names[i]] = sheets[i]
 	}
 	file.Sheet = sheetMap
-	f.Close()
 	return file, nil
 }


### PR DESCRIPTION
I dig around "archive/zip", then found a way to read a zip file in memory.But it need some change to `github.com/tealeg/xlsx`
caller code

``` golang
    r := bytes.NewReader(buf.Bytes())
    zr, err := zip.NewReader(r, int64(buf.Len()))
    t.Equal(err, nil)
    xlsxFile, err := xlsx.ReadZipReader(zr)
    t.Equal(err, nil)
```

https://github.com/bronze1man/kmg/blob/master/encoding/kmgExcel/WriteRead_test.go#L12
