### PR TITLE
Fix for multiple ranges in a row

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -372,8 +372,8 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File) ([]*Row, int, int) 
 			rows[insertRowIndex-minRow] = new(Row)
 			insertRowIndex++
 		}
-		// range is not empty
-		if len(rawrow.Spans) != 0 {
+		// range is not empty and only one range exist
+		if len(rawrow.Spans) != 0 && strings.Count(rawrow.Spans, ":") == 1 {
 			row = makeRowFromSpan(rawrow.Spans)
 		} else {
 			row = makeRowFromRaw(rawrow)


### PR DESCRIPTION
Some row has two ranges in spans, for example:

```
<row ... spans="1:10 6802:6802">
```

This xlsx file causes following panic:

```
panic: Invalid range (not integer in upper bound) 1:10 6802:6802
```

Changes:
- Call makeRowFromRaw instead of makeRowFromSpan
  when spans has 0 or 2 or more ":"
