### PR TITLE
styleIndex start from 0 and applyXxx ignored on most implementation

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -44,9 +44,9 @@ func (c *Cell) String() string {
 func (c *Cell) GetStyle() *Style {
 	style := &Style{}
 
-	if c.styleIndex > 0 && c.styleIndex <= len(c.styles.CellXfs) {
-		xf := c.styles.CellXfs[c.styleIndex-1]
-		if xf.ApplyBorder {
+	if c.styleIndex >= 0 && c.styleIndex < len(c.styles.CellXfs) {
+		xf := c.styles.CellXfs[c.styleIndex]
+		if xf.BorderId >= 0 && xf.BorderId < len(c.styles.Borders) {
 			var border Border
 			border.Left = c.styles.Borders[xf.BorderId].Left.Style
 			border.Right = c.styles.Borders[xf.BorderId].Right.Style
@@ -54,14 +54,14 @@ func (c *Cell) GetStyle() *Style {
 			border.Bottom = c.styles.Borders[xf.BorderId].Bottom.Style
 			style.Border = border
 		}
-		if xf.ApplyFill {
+		if xf.FillId >= 0 && xf.FillId < len(c.styles.Fills) {
 			var fill Fill
 			fill.PatternType = c.styles.Fills[xf.FillId].PatternFill.PatternType
 			fill.BgColor = c.styles.Fills[xf.FillId].PatternFill.BgColor.RGB
 			fill.FgColor = c.styles.Fills[xf.FillId].PatternFill.FgColor.RGB
 			style.Fill = fill
 		}
-		if xf.ApplyFont {
+		if xf.FontId >= 0 && xf.FontId < len(c.styles.Fonts) {
 			font := c.styles.Fonts[xf.FontId]
 			style.Font = Font{}
 			style.Font.Size, _ = strconv.Atoi(font.Sz.Val)

--- a/lib_test.go
+++ b/lib_test.go
@@ -73,7 +73,7 @@ func (l *LibSuite) TestGetStyleWithFonts(c *C) {
 
 	xStyles = &xlsxStyles{Fonts: fonts, CellXfs: cellXfs}
 
-	cell = &Cell{Value: "123", styleIndex: 1, styles: xStyles}
+	cell = &Cell{Value: "123", styleIndex: 0, styles: xStyles}
 	style = cell.GetStyle()
 	c.Assert(style, NotNil)
 	c.Assert(style.Font.Size, Equals, 10)
@@ -99,7 +99,7 @@ func (l *LibSuite) TestGetStyleWithFills(c *C) {
 
 	xStyles = &xlsxStyles{Fills: fills, CellXfs: cellXfs}
 
-	cell = &Cell{Value: "123", styleIndex: 1, styles: xStyles}
+	cell = &Cell{Value: "123", styleIndex: 0, styles: xStyles}
 	style = cell.GetStyle()
 	fill := style.Fill
 	c.Assert(fill.PatternType, Equals, "solid")
@@ -127,7 +127,7 @@ func (l *LibSuite) TestGetStyleWithBorders(c *C) {
 
 	xStyles = &xlsxStyles{Borders: borders, CellXfs: cellXfs}
 
-	cell = &Cell{Value: "123", styleIndex: 1, styles: xStyles}
+	cell = &Cell{Value: "123", styleIndex: 0, styles: xStyles}
 	style = cell.GetStyle()
 	border := style.Border
 	c.Assert(border.Left, Equals, "thin")
@@ -257,6 +257,32 @@ func (l *LibSuite) TestReadWorkbookRelationsFromZipFileWithFunnyNames(c *C) {
 	row1 := bob.Rows[0]
 	cell1 := row1.Cells[0]
 	c.Assert(cell1.String(), Equals, "I am Bob")
+}
+
+func (l *LibSuite) TestGetStyleFromZipFile(c *C) {
+	var xlsxFile *File
+	var err error
+
+	xlsxFile, err = OpenFile("testfile.xlsx")
+	c.Assert(err, IsNil)
+	sheetCount := len(xlsxFile.Sheet)
+	c.Assert(sheetCount, Equals, 3)
+
+	tabelle1 := xlsxFile.Sheet["Tabelle1"]
+
+	row0 := tabelle1.Rows[0]
+	cellFoo := row0.Cells[0]
+	c.Assert(cellFoo.String(), Equals, "Foo")
+	c.Assert(cellFoo.GetStyle().Fill.BgColor, Equals, "FF33CCCC")
+
+	row1 := tabelle1.Rows[1]
+	cellQuuk := row1.Cells[1]
+	c.Assert(cellQuuk.String(), Equals, "Quuk")
+	c.Assert(cellQuuk.GetStyle().Border.Left, Equals, "thin")
+
+	cellBar := row0.Cells[1]
+	c.Assert(cellBar.String(), Equals, "Bar")
+	c.Assert(cellBar.GetStyle().Fill.BgColor, Equals, "")
 }
 
 func (l *LibSuite) TestLettersToNumeric(c *C) {


### PR DESCRIPTION
- styleIndex start from 0
  - test added (TestGetStyleFromZipFile)
- applyXxx ignored on most implementation
  - tested by MSExcel and LibreOffice (open testfile.xlsx on LibreOffice, you can confirmed A1 cell bgcolor. but applyFill doesn't defined on A1 cell.)
  - [It is not referred to by PHPExcel, either. 
    ](https://github.com/PHPOffice/PHPExcel/blob/develop/Classes/PHPExcel/Reader/Excel2007.php#L538)
