### PR TITLE
fix bug when parsing spreadsheets with text box

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -553,7 +553,9 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File) ([]*Row, int, int) 
 			row.Cells[cellX].date1904 = file.Date1904
 			insertColIndex++
 		}
-		rows[insertRowIndex-minRow] = row
+		if len(rows) > insertRowIndex-minRow {
+			rows[insertRowIndex-minRow] = row
+		}
 		insertRowIndex++
 	}
 	return rows, colCount, rowCount


### PR DESCRIPTION
@tealeg This is obviously an edge case but I found that when parsing an XLSX file that contains a text box, the library panics. I think this spreadsheet would work as an example:

https://docs.google.com/spreadsheets/d/1T5ZgUts1JFUBQnD8VnomfTV4yVfeNOBEfOQlRlW2zQQ/edit?usp=sharing

This patch fixes it for me. I have to admit I am not entirely sure why, so I hope the other tests pass still.
