### PR TITLE
Remove runtime package dependency when getting maximum cell indices

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"path"
 	"strconv"
 	"strings"


### PR DESCRIPTION
`int(^uint(0) >> 1)` will always return the maximum signed integer value for the current architecture. you can see some discussion [here](https://groups.google.com/forum/#!msg/golang-nuts/a9PitPAHSSU/ziQw1-QHw3EJ). 
