### PR TITLE
fixes #53 (files produced need repair)

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -75,7 +75,7 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable) *xlsxWorksheet {
 		xSheet.Row = append(xSheet.Row, xRow)
 	}
 
-	worksheet.Cols = xlsxCols{Col: make([]xlsxCol, maxCell)}
+	worksheet.Cols = xlsxCols{Col: []xlsxCol{}}
 	for _, col := range s.Cols {
 		worksheet.Cols.Col = append(worksheet.Cols.Col,
 			xlsxCol{Min: col.Min,

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -79,3 +79,41 @@ func (s *SheetSuite) TestMarshalSheet(c *C) {
   </worksheet>`
 	c.Assert(output.String(), Equals, expectedXLSXSheet)
 }
+
+func (s *SheetSuite) TestMarshalSheetWithMultipleCells(c *C) {
+	file := NewFile()
+	sheet := file.AddSheet("Sheet1")
+	row := sheet.AddRow()
+	cell := row.AddCell()
+	cell.Value = "A cell (with value 1)!"
+	cell = row.AddCell()
+	cell.Value = "A cell (with value 2)!"
+	refTable := NewSharedStringRefTable()
+	xSheet := sheet.makeXLSXSheet(refTable)
+
+	output := bytes.NewBufferString(xml.Header)
+	body, err := xml.MarshalIndent(xSheet, "  ", "  ")
+	c.Assert(err, IsNil)
+	c.Assert(body, NotNil)
+	_, err = output.Write(body)
+	c.Assert(err, IsNil)
+	expectedXLSXSheet := `<?xml version="1.0" encoding="UTF-8"?>
+  <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+    <dimension ref="A1:B1"></dimension>
+    <cols>
+      <col min="1" max="1"></col>
+      <col min="2" max="2"></col>
+    </cols>
+    <sheetData>
+      <row r="1">
+        <c r="A1" t="s">
+          <v>0</v>
+        </c>
+        <c r="B1" t="s">
+          <v>1</v>
+        </c>
+      </row>
+    </sheetData>
+  </worksheet>`
+	c.Assert(output.String(), Equals, expectedXLSXSheet)
+}


### PR DESCRIPTION
The problem was that when we build the final object tree for marshalling
in XML, we use make([]Col, MaxCell) and then use append on the resulting
array. This has the undesired effect of initializing an array with a
number of empty cells and then appending to that array. The result is that
the final XML contains a bunch of empty column definitions before the
real columns start.
