### PR TITLE
Add boolean Hidden field on Sheet

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -324,8 +324,9 @@ func getValueFromCellData(rawcell xlsxC, reftable *RefTable) string {
 }
 
 // readRowsFromSheet is an internal helper function that extracts the
-// rows from a XSLXWorksheet, poulates them with Cells and resolves
+// rows from a XSLXWorksheet, populates them with Cells and resolves
 // the value references from the reference table and stores them in
+// the rows and columns.
 func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File) ([]*Row, []*Col, int, int) {
 	var rows []*Row
 	var cols []*Col
@@ -440,6 +441,7 @@ func readSheetFromFile(sc chan *indexedSheet, index int, rsheet xlsxSheet, fi *F
 	}
 	sheet := new(Sheet)
 	sheet.Rows, sheet.Cols, sheet.MaxCol, sheet.MaxRow = readRowsFromSheet(worksheet, fi)
+	sheet.Hidden = rsheet.State == sheetStateHidden || rsheet.State == sheetStateVeryHidden
 	result.Sheet = sheet
 	sc <- result
 }
@@ -471,6 +473,7 @@ func readSheetsFromZipFile(f *zip.File, file *File, sheetXMLMap map[string]strin
 	for i, rawsheet := range workbook.Sheets.Sheet {
 		go readSheetFromFile(sheetChan, i, rawsheet, file, sheetXMLMap)
 	}
+
 	for j := 0; j < sheetCount; j++ {
 		sheet := <-sheetChan
 		if sheet.Error != nil {

--- a/sheet.go
+++ b/sheet.go
@@ -13,6 +13,7 @@ type Sheet struct {
 	Cols   []*Col
 	MaxRow int
 	MaxCol int
+	Hidden bool
 }
 
 // Add a new Row to a Sheet

--- a/xmlWorkbook.go
+++ b/xmlWorkbook.go
@@ -7,6 +7,14 @@ import (
 	"io"
 )
 
+const (
+	// sheet state values as defined by
+	// http://msdn.microsoft.com/en-us/library/office/documentformat.openxml.spreadsheet.sheetstatevalues.aspx
+	sheetStateVisible    = "visible"
+	sheetStateHidden     = "hidden"
+	sheetStateVeryHidden = "veryHidden"
+)
+
 // xmlxWorkbookRels contains xmlxWorkbookRelations
 // which maps sheet id and sheet XML
 type xlsxWorkbookRels struct {

--- a/xmlWorkbook_test.go
+++ b/xmlWorkbook_test.go
@@ -35,13 +35,16 @@ func (w *WorkbookSuite) TestUnmarshallWorkbookXML(c *C) {
           <sheets>
             <sheet name="Sheet1"
                    sheetId="1"
-                   r:id="rId1"/>
+                   r:id="rId1"
+                   state="visible"/>
             <sheet name="Sheet2"
                    sheetId="2"
-                   r:id="rId2"/>
+                   r:id="rId2"
+                   state="hidden"/>
             <sheet name="Sheet3"
                    sheetId="3"
-                   r:id="rId3"/>
+                   r:id="rId3"
+                   state="veryHidden"/>
           </sheets>
           <definedNames>
             <definedName name="monitors"
@@ -70,6 +73,7 @@ func (w *WorkbookSuite) TestUnmarshallWorkbookXML(c *C) {
 	c.Assert(sheet.Id, Equals, "rId1")
 	c.Assert(sheet.Name, Equals, "Sheet1")
 	c.Assert(sheet.SheetId, Equals, "1")
+	c.Assert(sheet.State, Equals, "visible")
 	c.Assert(workbook.DefinedNames.DefinedName, HasLen, 1)
 	dname := workbook.DefinedNames.DefinedName[0]
 	c.Assert(dname.Data, Equals, "Sheet1!$A$1533")


### PR DESCRIPTION
A sheet may be hidden, as specified by the state attribute on the sheet tag. It is good to provide
this information to users of the API. See [spec](http://msdn.microsoft.com/en-us/library/office/documentformat.openxml.spreadsheet.sheetstatevalues.aspx) for more details

There are two possible hidden values, `hidden` and `veryHidden`, but I thought it's probably simpler to only expose whether it is hidden or not. I'll be happy to make any changes!
