### PR TITLE
Added functionality for writing a struct to a row

### DIFF
--- a/write.go
+++ b/write.go
@@ -16,7 +16,7 @@ func (r *Row) WriteStruct(e interface{}, cols int) int {
 	}
 
 	n := v.NumField() // number of fields in struct
-	if cols < n && cols > 0 {
+	if cols < n {
 		n = cols
 	}
 

--- a/write.go
+++ b/write.go
@@ -1,0 +1,44 @@
+package xlsx
+
+import "reflect"
+
+// Writes a struct to row r. Accepts a pointer to struct type 'e',
+// and the number of columns to write, `cols`. Returns -1 if the 'e'
+// doesn't point to a struct, otherwise the number of columns written
+func (r *Row) WriteStruct(e interface{}, cols int) int {
+	if cols == 0 {
+		return cols
+	}
+
+	v := reflect.ValueOf(e).Elem()
+	if v.Kind() != reflect.Struct {
+		return -1 // bail if it's not a struct
+	}
+
+	n := v.NumField() // number of fields in struct
+	if cols < n && cols > 0 {
+		n = cols
+	}
+
+	var k int
+	for i := 0; i < n; i, k = i+1, k+1 {
+		f := v.Field(i).Kind()
+		cell := r.AddCell()
+
+		switch f {
+		case reflect.Int, reflect.Int8, reflect.Int16,
+			reflect.Int32, reflect.Int64:
+			cell.SetInt(v.Field(i).Interface().(int))
+		case reflect.String:
+			cell.SetString(v.Field(i).Interface().(string))
+		case reflect.Float64, reflect.Float32:
+			cell.SetFloat(v.Field(i).Interface().(float64))
+		case reflect.Bool:
+			cell.SetBool(v.Field(i).Interface().(bool))
+		default:
+			k-- // nothing set so reset to previous
+		}
+	}
+
+	return k
+}

--- a/write.go
+++ b/write.go
@@ -16,7 +16,7 @@ func (r *Row) WriteStruct(e interface{}, cols int) int {
 	}
 
 	n := v.NumField() // number of fields in struct
-	if cols < n {
+	if cols < n && cols > 0 {
 		n = cols
 	}
 

--- a/write_test.go
+++ b/write_test.go
@@ -1,0 +1,44 @@
+package xlsx
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type WriteSuite struct{}
+
+var _ = Suite(&WriteSuite{})
+
+// Test if we can write a struct to a row
+func (r *RowSuite) TestWriteStruct(c *C) {
+	var f *File
+	f = NewFile()
+	sheet := f.AddSheet("Test1")
+	row := sheet.AddRow()
+	type e struct {
+		FirstName string
+		Age       int
+		GPA       float64
+		LikesPHP  bool
+	}
+	testStruct := e{
+		"Eric",
+		20,
+		3.94,
+		false,
+	}
+	row.WriteStruct(&testStruct, -1)
+	c.Assert(row, NotNil)
+
+	c0 := row.Cells[0].String()
+	c1, e1 := row.Cells[1].Int()
+	c2, e2 := row.Cells[2].Float()
+	c3 := row.Cells[3].Bool()
+
+	c.Assert(c0, Equals, "Eric")
+	c.Assert(c1, Equals, 20)
+	c.Assert(c2, Equals, 3.94)
+	c.Assert(c3, Equals, false)
+
+	c.Assert(e1, Equals, nil)
+	c.Assert(e2, Equals, nil)
+}


### PR DESCRIPTION
I needed this for a project of mine so I figured it'd be useful. It allows the writing of any struct (e.g. `type Person struct{}`) to a row, cell-by-cell.

This library doesn't have support for writing `int64` to a cell, so on a 32-bit platform it may overflow an `int64` member. I could submit a PR that adds a `SetInt64` function or just change `SetInt` to `int64`