### PR TITLE
Fix number formats in workbooks where no custom formats are created

### DIFF
--- a/xmlStyle.go
+++ b/xmlStyle.go
@@ -186,9 +186,10 @@ func (styles *xlsxStyleSheet) getNumberFormat(styleIndex int) string {
 	var numberFormat string = ""
 	if styleIndex > -1 && styleIndex <= styles.CellXfs.Count {
 		xf := styles.CellXfs.Xf[styleIndex]
-		if xf.NumFmtId < 164 {
-			return getBuiltinNumberFormat(xf.NumFmtId)
-		} else if styles.numFmtRefTable != nil {
+		if builtin := getBuiltinNumberFormat(xf.NumFmtId); builtin != "" {
+			return builtin
+		}
+		if styles.numFmtRefTable != nil {
 			numFmt := styles.numFmtRefTable[xf.NumFmtId]
 			numberFormat = numFmt.FormatCode
 		}

--- a/xmlStyle.go
+++ b/xmlStyle.go
@@ -180,7 +180,7 @@ func getBuiltinNumberFormat(numFmtId int) string {
 }
 
 func (styles *xlsxStyleSheet) getNumberFormat(styleIndex int) string {
-	if styles.CellXfs.Xf == nil || styles.numFmtRefTable == nil {
+	if styles.CellXfs.Xf == nil {
 		return ""
 	}
 	var numberFormat string = ""
@@ -188,7 +188,7 @@ func (styles *xlsxStyleSheet) getNumberFormat(styleIndex int) string {
 		xf := styles.CellXfs.Xf[styleIndex]
 		if xf.NumFmtId < 164 {
 			return getBuiltinNumberFormat(xf.NumFmtId)
-		} else {
+		} else if styles.numFmtRefTable != nil {
 			numFmt := styles.numFmtRefTable[xf.NumFmtId]
 			numberFormat = numFmt.FormatCode
 		}


### PR DESCRIPTION
The map wasn't created until the first addFmt was called, which
isn't called for custom formats, which was preventing builtin
formats from being read.