### PR TITLE
correct text format mistakes in Cell.FormattedValue function

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -195,11 +195,11 @@ func (c *Cell) formatToInt(format string) string {
 func (c *Cell) FormattedValue() string {
 	var numberFormat string = c.GetNumberFormat()
 	switch numberFormat {
-	case "general":
+	case "general", "@":
 		return c.Value
 	case "0", "#,##0":
 		return c.formatToInt("%d")
-	case "0.00", "#,##0.00", "@":
+	case "0.00", "#,##0.00":
 		return c.formatToFloat("%.2f")
 	case "#,##0 ;(#,##0)", "#,##0 ;[red](#,##0)":
 		f, err := strconv.ParseFloat(c.Value, 64)


### PR DESCRIPTION
the cell's number format "@" suggests it should be treated as text, trying to call strconv.ParseFloat() on    it will cause the following error:
strconv.ParseFloat: parsing "xxx": invalid syntax