### PR TITLE
Improve boolean check.

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -155,7 +155,16 @@ func (c *Cell) SetBool(b bool) {
 // TODO: Determine if the current return value is
 // appropriate for types other than CellTypeBool.
 func (c *Cell) Bool() bool {
-	return c.Value == "1"
+	// If bool, just return the value.
+	if c.cellType == CellTypeBool {
+		return c.Value == "1"
+	}
+	// If numeric, base it on a non-zero.
+	if c.cellType == CellTypeNumeric {
+		return c.Value != "0"
+	}
+	// Return whether there's an empty string.
+	return c.Value != ""
 }
 
 // SetFormula sets the format string for a cell.

--- a/cell_test.go
+++ b/cell_test.go
@@ -295,3 +295,27 @@ func (s *CellSuite) TestOddInput(c *C) {
 	cell.numFmt = "@"
 	c.Assert(cell.String(), Equals, odd)
 }
+
+// TestBool tests basic Bool getting and setting booleans.
+func (s *CellSuite) TestBool(c *C) {
+	cell := Cell{}
+	cell.SetBool(true)
+	c.Assert(cell.Value, Equals, "1")
+	c.Assert(cell.Bool(), Equals, true)
+	cell.SetBool(false)
+	c.Assert(cell.Value, Equals, "0")
+	c.Assert(cell.Bool(), Equals, false)
+}
+
+// TestStringBool tests calling Bool on a non CellTypeBool value.
+func (s *CellSuite) TestStringBool(c *C) {
+	cell := Cell{}
+	cell.SetInt(0)
+	c.Assert(cell.Bool(), Equals, false)
+	cell.SetInt(1)
+	c.Assert(cell.Bool(), Equals, true)
+	cell.SetString("")
+	c.Assert(cell.Bool(), Equals, false)
+	cell.SetString("0")
+	c.Assert(cell.Bool(), Equals, true)
+}


### PR DESCRIPTION
Updates `Cell.Bool()` to more accurately return a boolean value based on the cell's type.

If it's a boolean cell type, return the boolean value.

If it's a numeric type, `False` for zero and `True` for anything else.

Otherwise, return `False` for `""` or `True` for anything else.