### PR TITLE
Fix for a nil formula when the raw cell type is error (e).

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -320,6 +320,9 @@ func formulaForCell(rawcell xlsxC, sharedFormulas map[int]sharedFormula) string 
 	var res string
 
 	f := rawcell.F
+	if f == nil {
+		return ""
+	}
 	if f.T == "shared" {
 		x, y, err := getCoordsFromCellIDString(rawcell.R)
 		if err != nil {
@@ -596,13 +599,6 @@ func readSheetsFromZipFile(f *zip.File, file *File, sheetXMLMap map[string]strin
 	defer close(sheetChan)
 
 	go func() {
-		defer func() {
-			if e := recover(); e != nil {
-				err = fmt.Errorf("%v", e)
-				result := &indexedSheet{Index: -1, Sheet: nil, Error: err}
-				sheetChan <- result
-			}
-		}()
 		err = nil
 		for i, rawsheet := range workbook.Sheets.Sheet {
 			readSheetFromFile(sheetChan, i, rawsheet, file, sheetXMLMap)

--- a/lib_test.go
+++ b/lib_test.go
@@ -894,3 +894,14 @@ func (l *LibSuite) TestSharedFormulas(c *C) {
 	c.Assert(row.Cells[1].Formula(), Equals, "2*B1")
 	c.Assert(row.Cells[2].Formula(), Equals, "2*C1")
 }
+
+// Avoid panic when cell.F.T is "e" (for error)
+func (l *LibSuite) TestFormulaForCellPanic(c *C) {
+	cell := xlsxC{R: "A1"}
+	// This line would panic before the fix.
+	sharedFormulas := make(map[int]sharedFormula)
+
+	// Not really an important test; getting here without a
+	// panic is the real win.
+	c.Assert(formulaForCell(cell, sharedFormulas), Equals, "")
+}


### PR DESCRIPTION
This fixes the problem and tests all still pass. But is it
the correct solution? Can we get rid of the recover() function?

Fixes #114.