### PR TITLE
fix adding duplicate NumFmt

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -70,7 +70,7 @@ func (c *Cell) String() string {
 
 // SetFloat sets the value of a cell to a float.
 func (c *Cell) SetFloat(n float64) {
-	c.SetFloatWithFormat(n, "0.00e+00")
+	c.SetFloatWithFormat(n, "general")
 }
 
 /*
@@ -88,7 +88,12 @@ func (c *Cell) SetFloat(n float64) {
 // SetFloatWithFormat sets the value of a cell to a float and applies
 // formatting to the cell.
 func (c *Cell) SetFloatWithFormat(n float64, format string) {
-	c.Value = strconv.FormatFloat(n, 'e', -1, 64)
+	// beauty the output when the float is small enough
+	if n != 0 && n < 0.00001 {
+		c.Value = strconv.FormatFloat(n, 'e', -1, 64)
+	} else {
+		c.Value = strconv.FormatFloat(n, 'f', -1, 64)
+	}
 	c.numFmt = format
 	c.formula = ""
 	c.cellType = CellTypeNumeric

--- a/cell_test.go
+++ b/cell_test.go
@@ -97,9 +97,21 @@ func (s *CellSuite) TestGetStyleWithBorders(c *C) {
 func (l *CellSuite) TestSetFloatWithFormat(c *C) {
 	cell := Cell{}
 	cell.SetFloatWithFormat(37947.75334343, "yyyy/mm/dd")
-	c.Assert(cell.Value, Equals, "3.794775334343e+04")
+	c.Assert(cell.Value, Equals, "37947.75334343")
 	c.Assert(cell.numFmt, Equals, "yyyy/mm/dd")
 	c.Assert(cell.Type(), Equals, CellTypeNumeric)
+}
+
+func (l *CellSuite) TestSetFloat(c *C) {
+	cell := Cell{}
+	cell.SetFloat(0)
+	c.Assert(cell.Value, Equals, "0")
+	cell.SetFloat(0.000005)
+	c.Assert(cell.Value, Equals, "5e-06")
+	cell.SetFloat(100.0)
+	c.Assert(cell.Value, Equals, "100")
+	cell.SetFloat(37947.75334343)
+	c.Assert(cell.Value, Equals, "37947.75334343")
 }
 
 // We can return a string representation of the formatted data

--- a/xmlStyle.go
+++ b/xmlStyle.go
@@ -30,22 +30,22 @@ var builtInNumFmt = map[int]string{
 	4:  "#,##0.00",
 	9:  "0%",
 	10: "0.00%",
-	11: "0.00E+00",
+	11: "0.00e+00",
 	12: "# ?/?",
 	13: "# ??/??",
 	14: "mm-dd-yy",
 	15: "d-mmm-yy",
 	16: "d-mmm",
 	17: "mmm-yy",
-	18: "h:mm AM/PM",
-	19: "h:mm:ss AM/PM",
+	18: "h:mm am/pm",
+	19: "h:mm:ss am/pm",
 	20: "h:mm",
 	21: "h:mm:ss",
 	22: "m/d/yy h:mm",
 	37: "#,##0 ;(#,##0)",
-	38: "#,##0 ;[Red](#,##0)",
+	38: "#,##0 ;[red](#,##0)",
 	39: "#,##0.00;(#,##0.00)",
-	40: "#,##0.00;[Red](#,##0.00)",
+	40: "#,##0.00;[red](#,##0.00)",
 	41: `_(* #,##0_);_(* \(#,##0\);_(* "-"_);_(@_)`,
 	42: `_("$"* #,##0_);_("$* \(#,##0\);_("$"* "-"_);_(@_)`,
 	43: `_(* #,##0.00_);_(* \(#,##0.00\);_(* "-"??_);_(@_)`,
@@ -53,7 +53,7 @@ var builtInNumFmt = map[int]string{
 	45: "mm:ss",
 	46: "[h]:mm:ss",
 	47: "mmss.0",
-	48: "##0.0E+0",
+	48: "##0.0e+0",
 	49: "@",
 }
 
@@ -154,7 +154,7 @@ func (styles *xlsxStyleSheet) getStyle(styleIndex int) (style *Style) {
 			if italic := xfont.I; italic != nil && italic.Val != "0" {
 				style.Font.Italic = true
 			}
-			if underline := xfont.U; underline != nil && underline.Val != "0"  {
+			if underline := xfont.U; underline != nil && underline.Val != "0" {
 				style.Font.Underline = true
 			}
 		}
@@ -285,6 +285,13 @@ func (styles *xlsxStyleSheet) newNumFmt(formatCode string) xlsxNumFmt {
 		return xlsxNumFmt{NumFmtId: numFmtId, FormatCode: formatCode}
 	}
 
+	// find the exist xlsxNumFmt
+	for _, numFmt := range styles.NumFmts.NumFmt {
+		if formatCode == numFmt.FormatCode {
+			return numFmt
+		}
+	}
+
 	// The user define NumFmtId. The one less than 164 in built in.
 	numFmtId = builtinNumFmtsCount + 1
 	styles.lock.Lock()
@@ -301,24 +308,21 @@ func (styles *xlsxStyleSheet) newNumFmt(formatCode string) xlsxNumFmt {
 	return xlsxNumFmt{NumFmtId: numFmtId, FormatCode: formatCode}
 }
 
-func (styles *xlsxStyleSheet) addNumFmt(xNumFmt xlsxNumFmt) (index int) {
+// addNumFmt add xlsxNumFmt if its not exist.
+func (styles *xlsxStyleSheet) addNumFmt(xNumFmt xlsxNumFmt) {
 	// don't add built in NumFmt
 	if xNumFmt.NumFmtId <= builtinNumFmtsCount {
-		return -1
+		return
 	}
-	numFmt, ok := styles.numFmtRefTable[xNumFmt.NumFmtId]
+	_, ok := styles.numFmtRefTable[xNumFmt.NumFmtId]
 	if !ok {
 		if styles.numFmtRefTable == nil {
 			styles.numFmtRefTable = make(map[int]xlsxNumFmt)
 		}
 		styles.NumFmts.NumFmt = append(styles.NumFmts.NumFmt, xNumFmt)
 		styles.numFmtRefTable[xNumFmt.NumFmtId] = xNumFmt
-		index = styles.NumFmts.Count
 		styles.NumFmts.Count += 1
-		return
 	}
-	numFmt.FormatCode = xNumFmt.FormatCode
-	return
 }
 
 func (styles *xlsxStyleSheet) Marshal() (result string, err error) {

--- a/xmlStyle_test.go
+++ b/xmlStyle_test.go
@@ -309,8 +309,10 @@ func (s *CellSuite) TestNewNumFmt(c *C) {
 	styles.NumFmts.NumFmt = make([]xlsxNumFmt, 0)
 
 	c.Assert(styles.newNumFmt("0"), DeepEquals, xlsxNumFmt{1, "0"})
+	c.Assert(styles.newNumFmt("0.00e+00"), DeepEquals, xlsxNumFmt{11, "0.00e+00"})
 	c.Assert(styles.newNumFmt("mm-dd-yy"), DeepEquals, xlsxNumFmt{14, "mm-dd-yy"})
 	c.Assert(styles.newNumFmt("hh:mm:ss"), DeepEquals, xlsxNumFmt{164, "hh:mm:ss"})
+	c.Assert(len(styles.NumFmts.NumFmt), Equals, 1)
 }
 
 func (s *CellSuite) TestAddNumFmt(c *C) {
@@ -318,8 +320,14 @@ func (s *CellSuite) TestAddNumFmt(c *C) {
 	styles.NumFmts = xlsxNumFmts{}
 	styles.NumFmts.NumFmt = make([]xlsxNumFmt, 0)
 
-	c.Assert(styles.addNumFmt(xlsxNumFmt{1, "0"}), Equals, -1)
-	c.Assert(styles.addNumFmt(xlsxNumFmt{14, "mm-dd-yy"}), Equals, -1)
-	c.Assert(styles.addNumFmt(xlsxNumFmt{164, "hh:mm:ss"}), DeepEquals, 0)
-	c.Assert(styles.addNumFmt(xlsxNumFmt{165, "yyyy/mm/dd"}), DeepEquals, 1)
+	styles.addNumFmt(xlsxNumFmt{1, "0"})
+	c.Assert(styles.NumFmts.Count, Equals, 0)
+	styles.addNumFmt(xlsxNumFmt{14, "mm-dd-yy"})
+	c.Assert(styles.NumFmts.Count, Equals, 0)
+	styles.addNumFmt(xlsxNumFmt{164, "hh:mm:ss"})
+	c.Assert(styles.NumFmts.Count, Equals, 1)
+	styles.addNumFmt(xlsxNumFmt{165, "yyyy/mm/dd"})
+	c.Assert(styles.NumFmts.Count, Equals, 2)
+	styles.addNumFmt(xlsxNumFmt{165, "yyyy/mm/dd"})
+	c.Assert(styles.NumFmts.Count, Equals, 2)
 }


### PR DESCRIPTION
fix adding duplicate NumFmt; 
fix the builtin number format code such as 00+E00 which was not recognized as builtin NumFormt. Microsoft Excel will warn the broken file when add builtin format code as a user defined NumFmt.

ea2b7067d5dde4c330450404001a103591440302 will output the float number according the number of the leading zero. e.g. the float less than 0.0001, such as 0.000005 will output as 5e-06, while 103.22 will output as origin.

