### PR TITLE
properly check column hidden for cell hidden logic

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -508,7 +508,8 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File) ([]*Row, []*Col, in
 				cell.numFmt = file.styles.getNumberFormat(rawcell.S)
 			}
 			cell.date1904 = file.Date1904
-			cell.Hidden = rawrow.Hidden || (len(cols) > cellX && cell.Hidden)
+			// Cell is considered hidden if the row or the column of this cell is hidden
+			cell.Hidden = rawrow.Hidden || (len(cols) > cellX && cols[cellX].Hidden)
 			insertColIndex++
 		}
 		if len(rows) > insertRowIndex {

--- a/lib_test.go
+++ b/lib_test.go
@@ -788,7 +788,7 @@ func (l *LibSuite) TestReadRowsFromSheetWithHiddenColumn(c *C) {
 		<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 		<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
 		    <si><t>This is a test.</t></si>
-		    <si><t>hidden</t></si>
+		    <si><t>This should be invisible.</t></si>
 		</sst>`)
 	var sheetxml = bytes.NewBufferString(`
 		<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -828,7 +828,7 @@ func (l *LibSuite) TestReadRowsFromSheetWithHiddenColumn(c *C) {
 
 	cell2 := row.Cells[1]
 	c.Assert(cell2.Type(), Equals, CellTypeString)
-	c.Assert(cell2.String(), Equals, "hidden")
+	c.Assert(cell2.String(), Equals, "This should be invisible.")
 	c.Assert(cell2.Hidden, Equals, true)
 }
 

--- a/lib_test.go
+++ b/lib_test.go
@@ -783,6 +783,55 @@ func (l *LibSuite) TestReadRowsFromSheetWithMultipleTypes(c *C) {
 	c.Assert(cell6.Value, Equals, "#DIV/0!")
 }
 
+func (l *LibSuite) TestReadRowsFromSheetWithHiddenColumn(c *C) {
+	var sharedstringsXML = bytes.NewBufferString(`
+		<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+		<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+		    <si><t>This is a test.</t></si>
+		    <si><t>hidden</t></si>
+		</sst>`)
+	var sheetxml = bytes.NewBufferString(`
+		<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+		<worksheet xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main"
+		    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main"
+		    xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+			<sheetViews><sheetView workbookViewId="0"/>
+			</sheetViews>
+			<sheetFormatPr customHeight="1" defaultColWidth="14.43" defaultRowHeight="15.75"/>
+			<cols>
+				<col hidden="1" max="2" min="2"/>
+			</cols>
+		    <sheetData>
+		        <row r="1">
+		            <c r="A1" s="1" t="s"><v>0</v></c>
+		            <c r="B1" s="1" t="s"><v>1</v></c>
+		        </row>
+		    </sheetData><drawing r:id="rId1"/></worksheet>`)
+	worksheet := new(xlsxWorksheet)
+	err := xml.NewDecoder(sheetxml).Decode(worksheet)
+	c.Assert(err, IsNil)
+	sst := new(xlsxSST)
+	err = xml.NewDecoder(sharedstringsXML).Decode(sst)
+	c.Assert(err, IsNil)
+	file := new(File)
+	file.referenceTable = MakeSharedStringRefTable(sst)
+	rows, _, maxCols, maxRows := readRowsFromSheet(worksheet, file)
+	c.Assert(maxRows, Equals, 1)
+	c.Assert(maxCols, Equals, 2)
+	row := rows[0]
+	c.Assert(len(row.Cells), Equals, 2)
+
+	cell1 := row.Cells[0]
+	c.Assert(cell1.Type(), Equals, CellTypeString)
+	c.Assert(cell1.String(), Equals, "This is a test.")
+	c.Assert(cell1.Hidden, Equals, false)
+
+	cell2 := row.Cells[1]
+	c.Assert(cell2.Type(), Equals, CellTypeString)
+	c.Assert(cell2.String(), Equals, "hidden")
+	c.Assert(cell2.Hidden, Equals, true)
+}
+
 // When converting the xlsxRow to a Row we create a as many cells as we find.
 func (l *LibSuite) TestReadRowFromRaw(c *C) {
 	var rawRow xlsxRow


### PR DESCRIPTION
There is a bug with hidden cells introduced in this commit.
https://github.com/tealeg/xlsx/commit/00de551dc6de154cfa6db6b102a41448b251b8ad#diff-1861a0c40780efdec0f4e6e2e19b3d44R429

```diff
-			row.Cells[cellX].date1904 = file.Date1904
-			row.Cells[cellX].Hidden = rawrow.Hidden || (len(cols) > cellX && cols[cellX].Hidden)
+			cell.date1904 = file.Date1904
+			cell.Hidden = rawrow.Hidden || (len(cols) > cellX && cell.Hidden)
```

`cell` is set to `row.Cells[cellX]` so replacing `cols[cellX].Hidden` with `cell.Hidden` is incorrect. I changed it back to `cols[cellX].Hidden` so that the column hidden status is properly checked. I also added a test case for this.