### PR TITLE
Fix panic on invalid value for "r" attribute in <row>.

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -471,13 +471,17 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File) ([]*Row, []*Col, in
 		rows[rowIndex] = makeEmptyRow()
 	}
 
+	numRows := len(rows)
 	for rowIndex := 0; rowIndex < len(Worksheet.SheetData.Row); rowIndex++ {
 		rawrow := Worksheet.SheetData.Row[rowIndex]
 		// Some spreadsheets will omit blank rows from the
 		// stored data
 		for rawrow.R > (insertRowIndex + 1) {
 			// Put an empty Row into the array
-			rows[insertRowIndex-minRow] = makeEmptyRow()
+			index := insertRowIndex - minRow
+			if index < numRows {
+				rows[index] = makeEmptyRow()
+			}
 			insertRowIndex++
 		}
 		// range is not empty and only one range exist


### PR DESCRIPTION
The value of the "r" attribute of a <row> was being used as part of a test
in a loop which loaded default values into a row. However, the value in
the attribute could be higher than the number of rows, causing a panic
due to an index error.

fixes #125