### PR TITLE
Adds a test the randomly modifies parts of working xlsx documents

### DIFF
--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -1,0 +1,241 @@
+package xlsx
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	. "gopkg.in/check.v1"
+	"io"
+	"log"
+	"math/rand"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type Fuzzy struct{}
+
+var _ = Suite(&Fuzzy{})
+var randseed *int64 = flag.Int64("test.seed", time.Now().Unix(), "Set the random seed of the test for repeatable results")
+
+type tokenchange struct {
+	file bytes.Buffer
+	old  xml.Token
+	new  xml.Token
+}
+
+type filechange struct {
+	File *zip.Reader
+	Name string
+	Old  xml.Token
+	New  xml.Token
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+var numbers = []rune("0123456789")
+
+func randString(n int) []byte {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return []byte(string(b))
+}
+
+func randInt(n int) []byte {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = numbers[rand.Intn(len(numbers))]
+	}
+	return []byte(string(b))
+}
+
+//This function creates variations on tokens without regards as to positions in the file.
+func getTokenVariations(t xml.Token) []xml.Token {
+	var result []xml.Token = make([]xml.Token, 0)
+	switch t := t.(type) {
+	case xml.CharData:
+		{
+			//If the token is a number try some random number
+			if _, err := strconv.Atoi(string(t)); err == nil {
+				result = append(result, xml.CharData(randInt(rand.Intn(15))))
+			}
+
+			result = append(result, xml.CharData(randString(rand.Intn(100))))
+			return result
+		}
+	case xml.StartElement:
+		{
+			for k := range t.Attr {
+				if _, err := strconv.Atoi(string(t.Attr[k].Value)); err == nil {
+					start := xml.CopyToken(t).(xml.StartElement)
+					start.Attr[k].Value = string(randInt(rand.Intn(15)))
+					result = append(result, start)
+				}
+				start := xml.CopyToken(t).(xml.StartElement)
+				start.Attr[k].Value = string(randString(rand.Intn(100)))
+				result = append(result, start)
+			}
+			return result
+		}
+
+	default:
+		{
+			return make([]xml.Token, 0) // No variations on non char tokens yet
+		}
+	}
+}
+
+func variationsXML(f *zip.File) chan tokenchange {
+	result := make(chan tokenchange)
+	r, _ := f.Open()
+	xmlReader := xml.NewDecoder(r)
+	var tokenList []xml.Token
+	for {
+		if t, err := xmlReader.Token(); err == nil {
+			tokenList = append(tokenList, xml.CopyToken(t))
+		} else {
+			break
+		}
+	}
+
+	go func() {
+		//Over every token we want to break
+		for TokenToBreak, _ := range tokenList {
+			//Get the ways we can break that token
+			for _, brokenToken := range getTokenVariations(tokenList[TokenToBreak]) {
+				var buf bytes.Buffer
+				xmlWriter := xml.NewEncoder(&buf)
+				//Now create an xml file where one token is broken
+				for currentToken, t := range tokenList {
+					if currentToken == TokenToBreak {
+						xmlWriter.EncodeToken(brokenToken)
+					} else {
+						xmlWriter.EncodeToken(t)
+					}
+				}
+				xmlWriter.Flush()
+				result <- tokenchange{buf, tokenList[TokenToBreak], brokenToken}
+			}
+		}
+		close(result)
+	}()
+	return result
+}
+
+func generateBrokenFiles(r *zip.Reader) chan filechange {
+	result := make(chan filechange)
+	go func() {
+		count := 0
+		//For every file in the zip we want variation on
+		for breakIndex, fileToBreak := range r.File {
+			if filepath.Ext(fileToBreak.Name) != ".xml" {
+				continue //We cannot create variations on non-xml files
+			}
+
+			variationCount := 0
+			//For every broken version of that file
+			for changedFile := range variationsXML(fileToBreak) {
+				variationCount++
+				var buffer bytes.Buffer
+				//Create a new xlsx file in memory
+				outZip := zip.NewWriter(&buffer)
+				w, err := outZip.Create(fileToBreak.Name)
+				if err != nil {
+					log.Fatal(err)
+				}
+				//Add modified file to xlsx
+				_, err = changedFile.file.WriteTo(w)
+				if err != nil {
+					log.Fatal("changedFile.file.WriteTo", err)
+				}
+				//Add other, unchanged, files.
+				for otherIndex, otherFile := range r.File {
+					if breakIndex == otherIndex {
+						continue
+					}
+					to, err := outZip.Create(otherFile.Name)
+					if err != nil {
+						log.Fatal("Could not add new file to xlsx due to", err)
+					}
+					from, err := otherFile.Open()
+					if err != nil {
+						log.Fatal("Could not open original file from template xlsx due to", err)
+					}
+					io.Copy(to, from)
+					from.Close()
+				}
+				outZip.Close()
+
+				//Return this combination of broken files
+				b := buffer.Bytes()
+				var res filechange
+				res.File, _ = zip.NewReader(bytes.NewReader(b), int64(len(b)))
+				res.Name = fileToBreak.Name
+				res.Old = changedFile.old
+				res.New = changedFile.new
+				result <- res
+				count++
+			}
+		}
+		close(result)
+	}()
+	return result
+}
+
+func Raises(f func()) (err interface{}) {
+	defer func() {
+		err = recover()
+	}()
+	err = nil
+	f()
+	return
+}
+
+func tokenToString(t xml.Token) string {
+	switch t := t.(type) {
+	case xml.CharData:
+		{
+			return string(t)
+		}
+	default:
+		{
+			return fmt.Sprint(t)
+		}
+	}
+}
+
+func (f *Fuzzy) TestRandomBrokenParts(c *C) {
+	if testing.Short() {
+		c.Log("This test, tests many versions of an xlsx file and might take a while, it is being skipped")
+		c.SucceedNow()
+	}
+	log.Println("Fuzzy test is using this -test.seed="+strconv.FormatInt(*randseed,10))
+	rand.Seed(*randseed)
+	template, err := zip.OpenReader("./testdocs/testfile.xlsx")
+	c.Assert(err, IsNil)
+	defer template.Close()
+
+	count := 0
+
+	for brokenFile := range generateBrokenFiles(&template.Reader) {
+		count++
+		if testing.Verbose() {
+			//If the library panics fatally it would be nice to know why
+			log.Println("Testing change to ", brokenFile.Name, " on token ", tokenToString(brokenFile.Old), " of type ", reflect.TypeOf(brokenFile.Old), " to ", tokenToString(brokenFile.New))
+		}
+
+		if e := Raises(func() { ReadZipReader(brokenFile.File) }); e != nil {
+
+			c.Log("Some file with random changes did raise an exception instead of returning an error", e)
+			c.Log("Testing change to ", brokenFile.Name, " on token ", tokenToString(brokenFile.Old), " of type ", reflect.TypeOf(brokenFile.Old), " to ", tokenToString(brokenFile.New))
+			c.FailNow()
+		}
+
+	}
+	c.Succeed()
+}


### PR DESCRIPTION
The library is given a slightly modified version of testfile.xlsx and tested for uncaught panics.

There are a few problems with the test, but I see no way around them:
The library panics in a goroutine and terminates the test, without the test every printing logged output, thus printing information to stdout as the test proceeds is the only way of getting output. I suppressed output unless the `-test.v` flag is set. The test always prints the random seed (the only line alway printed) that is is using in order for the test to be repeatable should it fail(set using `-test.seed`).
Thus when running the test the seed will be output, if it it fails the test can be rerun with the `-test.v` and `-test.seed=<seed>` flags to see what modification to the file broke the library. 

The test currently modifies tags and attributes to random strings and random integers(if the token was an integer before the modification). More modifications can be added to getTokenVariations.

The test fails due to a few different issues, some of them will require a significant rewrite of logic of some parts. I will briefly list the ones I have discovered:
* lib.go:390: the panic goes uncaught. My suggestion would be to return an error as the calling function might want to close a channel.

* reftable.go:55: ResolveSharedString might not be able to resolve an index, but this is not reported/handled. fillCellData might want to return a reasonable error should this occur.

* lib.go:609: The reader closes the channel, where the writer should. This causes writes on closed channels if an error is encountered. Moving the `defer close(sheetChan)` inside the goroutine on line 611 will solve this problem. The deferred function can then also set err, allowing readSheetsFromZipFile to correctly reporting errors. The loop starting on 618 is incorrectly stated, no assumption should be made as to the number of values written to the channel as the writer can panic. Changing it to `for sheet := range sheetChan{}` will correctly loop over the channel.

* lib.go:168: getCoordsFromCellIDString is far too graceful in the values it parses. (it parses MEbdVxTTqE6eebrPCMPNIzmF5Xx5JPup8Q35ipbw2OK without an error)
*lib.go:442: rowCount and colCount is 'inaccurate', if only one cell at ZZ26 has a value all cell/rows from A1 will be allocated. The rest of the library depends on those rows/cols existing even though they do not contain information. This mostly just inefficient, but a sheet crafted with a singular cell at a very large index can crash the library (make panics with makeslice: len out of range ).

* An error not tested for by this test, is missing files. Some files are expected and the library panics fatally is the do not exist.

Any advice around simpler testing setup and test output would be appreciated. 

