### PR TITLE
Fix doc comment for XLSXReaderError.Error()

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -17,8 +17,8 @@ type XLSXReaderError struct {
 	Err string
 }
 
-// String() returns a string value from an XLSXReaderError struct in
-// order that it might comply with the os.Error interface.
+// Error returns a string value from an XLSXReaderError struct in order
+// that it might comply with the builtin.error interface.
 func (e *XLSXReaderError) Error() string {
 	return e.Err
 }


### PR DESCRIPTION
Comment referred to the method as "String()" instead of "Error" and referred to the "`os.Error` interface" instead of the `builtin.error` interface. `os.Error` hasn't been around since before Go 1, AFAIK.