### PR TITLE
get parsing error string when fetching the formated value for a wrong format cell

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -278,7 +278,7 @@ func (c *Cell) GetNumberFormat() string {
 func (c *Cell) formatToFloat(format string) string {
 	f, err := strconv.ParseFloat(c.Value, 64)
 	if err != nil {
-		return err.Error()
+		return c.Value
 	}
 	return fmt.Sprintf(format, f)
 }
@@ -286,7 +286,7 @@ func (c *Cell) formatToFloat(format string) string {
 func (c *Cell) formatToInt(format string) string {
 	f, err := strconv.ParseFloat(c.Value, 64)
 	if err != nil {
-		return err.Error()
+		return c.Value
 	}
 	return fmt.Sprintf(format, int(f))
 }
@@ -309,7 +309,7 @@ func (c *Cell) FormattedValue() string {
 	case "#,##0 ;(#,##0)", "#,##0 ;[red](#,##0)":
 		f, err := strconv.ParseFloat(c.Value, 64)
 		if err != nil {
-			return err.Error()
+			return c.Value
 		}
 		if f < 0 {
 			i := int(math.Abs(f))
@@ -320,7 +320,7 @@ func (c *Cell) FormattedValue() string {
 	case "#,##0.00;(#,##0.00)", "#,##0.00;[red](#,##0.00)":
 		f, err := strconv.ParseFloat(c.Value, 64)
 		if err != nil {
-			return err.Error()
+			return c.Value
 		}
 		if f < 0 {
 			return fmt.Sprintf("(%.2f)", f)
@@ -329,14 +329,14 @@ func (c *Cell) FormattedValue() string {
 	case "0%":
 		f, err := strconv.ParseFloat(c.Value, 64)
 		if err != nil {
-			return err.Error()
+			return c.Value
 		}
 		f = f * 100
 		return fmt.Sprintf("%d%%", int(f))
 	case "0.00%":
 		f, err := strconv.ParseFloat(c.Value, 64)
 		if err != nil {
-			return err.Error()
+			return c.Value
 		}
 		f = f * 100
 		return fmt.Sprintf("%.2f%%", f)
@@ -350,7 +350,7 @@ func (c *Cell) FormattedValue() string {
 func parseTime(c *Cell) string {
 	f, err := strconv.ParseFloat(c.Value, 64)
 	if err != nil {
-		return err.Error()
+		return c.Value
 	}
 	val := TimeFromExcelTime(f, c.date1904)
 	format := c.GetNumberFormat()

--- a/cell_test.go
+++ b/cell_test.go
@@ -126,6 +126,10 @@ func (l *CellSuite) TestFormattedValue(c *C) {
 	negativeCell.numFmt = "general"
 	c.Assert(negativeCell.FormattedValue(), Equals, "-37947.7500001")
 
+	// Test for a string cell but uses a numberic format
+	specialStringCell := Cell{numFmt: "0.00", Value: "string"}
+	c.Assert(specialStringCell.FormattedValue(), Equals, "string")
+
 	// TODO: This test is currently broken.  For a string type cell, I
 	// don't think FormattedValue() should be doing a numeric conversion on the value
 	// before returning the string.


### PR DESCRIPTION
Fix: get parsing error string when fetching the formated value for a cell with a wrong format.

In office, the cell whose value is a string or other type value can be set with a improper format. When parsing these value with the wrong format, FormattedValue will return the error string but not the value, such as: "strconv.ParseFloat: parsing \"string\": invalid syntax".

I think it's a improper behavior, so I commit this patch which will return the origin value when failing to parse.