### PR TITLE
Apply customWidth attribute to cols and enable changing defaults

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -110,6 +110,11 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 	maxRow := 0
 	maxCell := 0
 
+	if s.SheetFormat.DefaultRowHeight != 0 {
+		worksheet.SheetFormatPr.DefaultRowHeight = s.SheetFormat.DefaultRowHeight
+	}
+	worksheet.SheetFormatPr.DefaultColWidth = s.SheetFormat.DefaultColWidth
+
 	colsXfIdList := make([]int, len(s.Cols))
 	worksheet.Cols = xlsxCols{Col: []xlsxCol{}}
 	for c, col := range s.Cols {

--- a/sheet.go
+++ b/sheet.go
@@ -54,8 +54,7 @@ func (s *Sheet) maybeAddCol(cellCount int) {
 			Min:       cellCount,
 			Max:       cellCount,
 			Hidden:    false,
-			Collapsed: false,
-			Width:     ColWidth}
+			Collapsed: false}
 		s.Cols = append(s.Cols, col)
 		s.MaxCol = cellCount
 	}
@@ -128,16 +127,20 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 		}
 		colsXfIdList[c] = XfId
 
+		var customWidth int
 		if col.Width == 0 {
 			col.Width = ColWidth
+		} else {
+			customWidth = 1
 		}
 		worksheet.Cols.Col = append(worksheet.Cols.Col,
 			xlsxCol{Min: col.Min,
-				Max:       col.Max,
-				Hidden:    col.Hidden,
-				Width:     col.Width,
-				Collapsed: col.Collapsed,
-				Style:     XfId,
+				Max:         col.Max,
+				Hidden:      col.Hidden,
+				Width:       col.Width,
+				CustomWidth: customWidth,
+				Collapsed:   col.Collapsed,
+				Style:       XfId,
 			})
 	}
 

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -192,12 +192,13 @@ type xlsxCols struct {
 // currently I have not checked it for completeness - it does as much
 // as I need.
 type xlsxCol struct {
-	Collapsed bool    `xml:"collapsed,attr"`
-	Hidden    bool    `xml:"hidden,attr"`
-	Max       int     `xml:"max,attr"`
-	Min       int     `xml:"min,attr"`
-	Style     int     `xml:"style,attr"`
-	Width     float64 `xml:"width,attr"`
+	Collapsed   bool    `xml:"collapsed,attr"`
+	Hidden      bool    `xml:"hidden,attr"`
+	Max         int     `xml:"max,attr"`
+	Min         int     `xml:"min,attr"`
+	Style       int     `xml:"style,attr"`
+	Width       float64 `xml:"width,attr"`
+	CustomWidth int     `xml:"customWidth,attr,omitempty"`
 }
 
 // xlsxDimension directly maps the dimension element in the namespace


### PR DESCRIPTION
In Microsoft Excel for Mac 2011 width setting were not applied to columns. The attribute `customWidth` has to be set to `1` when a user has changed it ([DocumentFormat.OpenXml.Spreadsheet.Column](https://msdn.microsoft.com/en-us/library/documentformat.openxml.spreadsheet.column(v=office.14).aspx)). This has been remedied in this patch and the `customWidth` attribute is only applied when a user has explicitly changed the width of a column.

Previously default width was automatically applied during `maybeAddCol`, I removed it from here since it gets applied anyway in `makeXLSXSheet`. That way the we can check if `customWidth` need to be applied or not.

I also enabled modifications to `DefaultColWidth` and `DefaultRowHeight`. Now DefaultColWidth can be used instead of modifying each column separately.