### PR TITLE
Set Sheet attr of each Row in readSheetFromFile

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -585,6 +585,9 @@ func readSheetFromFile(sc chan *indexedSheet, index int, rsheet xlsxSheet, fi *F
 	sheet := new(Sheet)
 	sheet.File = fi
 	sheet.Rows, sheet.Cols, sheet.MaxCol, sheet.MaxRow = readRowsFromSheet(worksheet, fi)
+	for _, row := range sheet.Rows {
+		row.Sheet = sheet
+	}
 	sheet.Hidden = rsheet.State == sheetStateHidden || rsheet.State == sheetStateVeryHidden
 	sheet.SheetViews = readSheetViews(worksheet.SheetViews)
 


### PR DESCRIPTION
Should be self-explanatory. Otherwise doing things like `row.AddCell()` on a file you just read can panic on a nil pointer dereference.