### PR TITLE
Set ApplyNumberFormat in handleNumFmtIdForXLSX

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -277,6 +277,9 @@ func handleStyleForXLSX(style *Style, NumFmtId int, styles *xlsxStyleSheet) (XfI
 func handleNumFmtIdForXLSX(NumFmtId int, styles *xlsxStyleSheet) (XfId int) {
 	xCellXf := makeXLSXCellElement()
 	xCellXf.NumFmtId = NumFmtId
+	if xCellXf.NumFmtId > 0 {
+		xCellXf.ApplyNumberFormat = true
+	}
 	XfId = styles.addCellXf(xCellXf)
 	return
 }


### PR DESCRIPTION
As mentioned in #158, applyNumberFormat was always 0 in the output.

For some reason, Excel didn't care, but all the other clients I tried (Google docs, OpenOffice, Gnumeric) did care.

Fixes #158.