### PR TITLE
WIP: 147 nil row fix

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+    "log"
 	"strconv"
 	"strings"
 )
@@ -476,7 +477,9 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet) ([]*R
 	}
 
 	// insert leading empty rows that is in front of minRow
-	for rowIndex := 0; rowIndex < rowCount; rowIndex++ {
+    log.Println("got to that part")
+	for rowIndex := 0; rowIndex < minRow; rowIndex++ {
+	//for rowIndex := 0; rowIndex < rowCount; rowIndex++ {
 		rows[rowIndex] = makeEmptyRow(sheet)
 	}
 

--- a/lib.go
+++ b/lib.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-    "log"
 	"strconv"
 	"strings"
 )
@@ -477,9 +476,7 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet) ([]*R
 	}
 
 	// insert leading empty rows that is in front of minRow
-    log.Println("got to that part")
-	for rowIndex := 0; rowIndex < minRow; rowIndex++ {
-	//for rowIndex := 0; rowIndex < rowCount; rowIndex++ {
+	for rowIndex := 0; rowIndex < rowCount; rowIndex++ {
 		rows[rowIndex] = makeEmptyRow(sheet)
 	}
 

--- a/lib.go
+++ b/lib.go
@@ -476,7 +476,7 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet) ([]*R
 	}
 
 	// insert leading empty rows that is in front of minRow
-	for rowIndex := 0; rowIndex < minRow; rowIndex++ {
+	for rowIndex := 0; rowIndex < rowCount; rowIndex++ {
 		rows[rowIndex] = makeEmptyRow(sheet)
 	}
 

--- a/lib_test.go
+++ b/lib_test.go
@@ -3,7 +3,6 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
-    "log"
 	// "strconv"
 	"strings"
 
@@ -280,7 +279,7 @@ func (l *LibSuite) TestReadRowsFromSheet(c *C) {
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <dimension ref="A1:X9"/>
+  <dimension ref="A1:B2"/>
   <sheetViews>
     <sheetView tabSelected="1" workbookViewId="0">
       <selection activeCell="C2" sqref="C2"/>
@@ -297,20 +296,12 @@ func (l *LibSuite) TestReadRowsFromSheet(c *C) {
         <v>1</v>
       </c>
     </row>
-    <row r="3" spans="1:2">
-      <c r="A3" t="s">
+    <row r="2" spans="1:2">
+      <c r="A2" t="s">
+        <v>2</v>
+      </c>
+      <c r="B2" t="s">
         <v>3</v>
-      </c>
-      <c r="B3" t="s">
-        <v>3</v>
-      </c>
-    </row>
-    <row r="7" spans="1:2">
-      <c r="A7" t="s">
-        <v>7</v>
-      </c>
-      <c r="B7" t="s">
-        <v>7</v>
       </c>
     </row>
   </sheetData>
@@ -329,11 +320,7 @@ func (l *LibSuite) TestReadRowsFromSheet(c *C) {
 	file := new(File)
 	file.referenceTable = MakeSharedStringRefTable(sst)
 	sheet := new(Sheet)
-    log.Println("start of test")
 	rows, cols, maxCols, maxRows := readRowsFromSheet(worksheet, file, sheet)
-    for i, row := range rows {
-        log.Printf("row %d: %T\n", i, row)
-    }
 	c.Assert(maxRows, Equals, 2)
 	c.Assert(maxCols, Equals, 2)
 	row := rows[0]

--- a/lib_test.go
+++ b/lib_test.go
@@ -3,6 +3,7 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
+    "log"
 	// "strconv"
 	"strings"
 
@@ -279,7 +280,7 @@ func (l *LibSuite) TestReadRowsFromSheet(c *C) {
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <dimension ref="A1:B2"/>
+  <dimension ref="A1:X9"/>
   <sheetViews>
     <sheetView tabSelected="1" workbookViewId="0">
       <selection activeCell="C2" sqref="C2"/>
@@ -296,12 +297,20 @@ func (l *LibSuite) TestReadRowsFromSheet(c *C) {
         <v>1</v>
       </c>
     </row>
-    <row r="2" spans="1:2">
-      <c r="A2" t="s">
-        <v>2</v>
-      </c>
-      <c r="B2" t="s">
+    <row r="3" spans="1:2">
+      <c r="A3" t="s">
         <v>3</v>
+      </c>
+      <c r="B3" t="s">
+        <v>3</v>
+      </c>
+    </row>
+    <row r="7" spans="1:2">
+      <c r="A7" t="s">
+        <v>7</v>
+      </c>
+      <c r="B7" t="s">
+        <v>7</v>
       </c>
     </row>
   </sheetData>
@@ -320,7 +329,11 @@ func (l *LibSuite) TestReadRowsFromSheet(c *C) {
 	file := new(File)
 	file.referenceTable = MakeSharedStringRefTable(sst)
 	sheet := new(Sheet)
+    log.Println("start of test")
 	rows, cols, maxCols, maxRows := readRowsFromSheet(worksheet, file, sheet)
+    for i, row := range rows {
+        log.Printf("row %d: %T\n", i, row)
+    }
 	c.Assert(maxRows, Equals, 2)
 	c.Assert(maxCols, Equals, 2)
 	row := rows[0]


### PR DESCRIPTION
This is a work-in-progress because there are no tests.

@claudiofelber: The solution you mentioned in #147 was good, but checking on `rowCount` is better than  `maxRow`, because that would ignore the final row.

@tealeg: I had a lot of trouble writing a test for this. I actually made this fix weeks ago, but never pushed it due to that difficulty. I tried copy/pasting an existing test and changing the XML to put skip row numbers, but I couldn't get the desired output. Do you have any suggestions?