### PR TITLE
Fix "off by one" bug when the spreadsheet omits empty rows

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -487,9 +487,8 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet) ([]*R
 		// stored data
 		for rawrow.R > (insertRowIndex + 1) {
 			// Put an empty Row into the array
-			index := insertRowIndex - minRow
-			if index < numRows {
-				rows[index] = makeEmptyRow(sheet)
+			if insertRowIndex < numRows {
+				rows[insertRowIndex] = makeEmptyRow(sheet)
 			}
 			insertRowIndex++
 		}

--- a/lib_test.go
+++ b/lib_test.go
@@ -1068,3 +1068,60 @@ func (l *LibSuite) TestFormulaForCellPanic(c *C) {
 	// panic is the real win.
 	c.Assert(formulaForCell(cell, sharedFormulas), Equals, "")
 }
+
+func (l *LibSuite) TestRowNotOverwrittenWhenFollowedByEmptyRow(c *C) {
+	sheetXML := bytes.NewBufferString(`
+	<?xml version="1.0" encoding="UTF-8"?>
+	<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+		<sheetViews>
+			<sheetView workbookViewId="0" />
+		</sheetViews>
+		<sheetFormatPr customHeight="1" defaultColWidth="14.43" defaultRowHeight="15.75" />
+		<sheetData>
+			<row r="2">
+				<c r="A2" t="str">
+					<f t="shared" ref="A2" si="1">RANDBETWEEN(1,100)</f>
+					<v>66</v>
+				</c>
+			</row>
+			<row r="3">
+				<c r="A3" t="str">
+					<f t="shared" ref="A3" si="2">RANDBETWEEN(1,100)</f>
+					<v>30</v>
+				</c>
+			</row>
+			<row r="4">
+				<c r="A4" t="str">
+					<f t="shared" ref="A4" si="3">RANDBETWEEN(1,100)</f>
+					<v>75</v>
+				</c>
+			</row>
+			<row r="7">
+				<c r="A7" s="1" t="str">
+					<f t="shared" ref="A7" si="4">A4/A2</f>
+					<v>1.14</v>
+				</c>
+			</row>
+		</sheetData>
+		<drawing r:id="rId1" />
+	</worksheet>
+	`)
+
+	sharedstringsXML := bytes.NewBufferString(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>`)
+
+	worksheet := new(xlsxWorksheet)
+	xml.NewDecoder(sheetXML).Decode(worksheet)
+
+	sst := new(xlsxSST)
+	xml.NewDecoder(sharedstringsXML).Decode(sst)
+
+	file := new(File)
+	file.referenceTable = MakeSharedStringRefTable(sst)
+
+	sheet := new(Sheet)
+	rows, _, _, _ := readRowsFromSheet(worksheet, file, sheet)
+	cells := rows[3].Cells
+
+	c.Assert(cells, HasLen, 1)
+	c.Assert(cells[0].Value, Equals, "75")
+}


### PR DESCRIPTION
This fixes an issue where a row would be accidentally overwritten with a blank row, if the following (blank) row was omitted in the worksheet file.

[Here is a file](https://s3-eu-west-1.amazonaws.com/boxofrad/Shared/bug.xlsx) (exported from Google Sheets) that exposes the problem - It's not possible to access the cell at reference: **A4**.

I'm not sure what the original reason for subtracting the `minRow` was, but it seems erroneous to me.

Thanks! :sparkling_heart: 