### PR TITLE
Skip string literals when trying to shift cells in shared formula

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -340,8 +340,18 @@ func formulaForCell(rawcell xlsxC, sharedFormulas map[int]sharedFormula) string 
 				dy := y - sharedFormula.y
 				orig := []byte(sharedFormula.formula)
 				var start, end int
+				var stringLiteral bool
 				for end = 0; end < len(orig); end++ {
 					c := orig[end]
+
+					if c == '"' {
+						stringLiteral = !stringLiteral
+					}
+
+					if stringLiteral {
+						continue // Skip characters in quotes
+					}
+
 					if c >= 'A' && c <= 'Z' || c == '$' {
 						res += string(orig[start:end])
 						start = end

--- a/lib_test.go
+++ b/lib_test.go
@@ -1134,6 +1134,7 @@ func (l *LibSuite) TestSharedFormulasWithAbsoluteReferences(c *C) {
 		"A1+B$1",
 		"A1+$B$1",
 		"$A$1+$B$1",
+		`IF(C23>=E$12,"Q4",IF(C23>=$D$12,"Q3",IF(C23>=C$12,"Q2","Q1")))`,
 	}
 
 	expected := []string{
@@ -1148,6 +1149,7 @@ func (l *LibSuite) TestSharedFormulasWithAbsoluteReferences(c *C) {
 		"B2+C$1",
 		"B2+$B$1",
 		"$A$1+$B$1",
+		`IF(D24>=F$12,"Q4",IF(D24>=$D$12,"Q3",IF(D24>=D$12,"Q2","Q1")))`,
 	}
 
 	anchorCell := "C4"


### PR DESCRIPTION
### Problem / Feature

Will skip string literals in a formula, so we don't unintentionally shift those looking like cell labels.

For example, ```IF(C23>=E$12,"Q4",IF(C23>=$D$12,"Q3",IF(C23>=C$12,"Q2","Q1")))```, "Q4", "Q3", "Q2", and "Q1" should not be shifted.

Please review @tealeg  
Thanks!