### PR TITLE
Fixed DefinedNames.DefinedName pointer issue.

### DIFF
--- a/cell_test.go
+++ b/cell_test.go
@@ -347,6 +347,16 @@ func (l *CellSuite) TestFormattedValue(c *C) {
 	fvc.Equals(cell, "2003-11-22 18:00:00")
 	smallCell.NumFmt = "yyyy-mm-dd hh:mm:ss"
 	fvc.Equals(smallCell, "1899-12-30 00:14:47")
+
+	cell.NumFmt = "mmmm d, yyyy"
+	fvc.Equals(cell, "November 22, 2003")
+	smallCell.NumFmt = "mmmm d, yyyy"
+	fvc.Equals(smallCell, "December 30, 1899")
+
+	cell.NumFmt = "dddd, mmmm dd, yyyy"
+	fvc.Equals(cell, "Saturday, November 22, 2003")
+	smallCell.NumFmt = "dddd, mmmm dd, yyyy"
+	fvc.Equals(smallCell, "Saturday, December 30, 1899")
 }
 
 // test setters and getters

--- a/lib.go
+++ b/lib.go
@@ -684,8 +684,9 @@ func readSheetsFromZipFile(f *zip.File, file *File, sheetXMLMap map[string]strin
 	}
 	file.Date1904 = workbook.WorkbookPr.Date1904
 
-	for _, entry := range workbook.DefinedNames.DefinedName {
-		file.DefinedNames = append(file.DefinedNames, &entry)
+
+	for entryNum, _ := range workbook.DefinedNames.DefinedName {
+		file.DefinedNames = append(file.DefinedNames, &workbook.DefinedNames.DefinedName[entryNum])
 	}
 
 	// Only try and read sheets that have corresponding files.


### PR DESCRIPTION
file.DefinedNames would be an array of the proper size, but all values would be the last &entry, as they were all referencing the same memory location. 

e.g. 
**Memory addresses and values before fix (file with three defined names):**
[0xc8201363c0 0xc8201363c0 0xc8201363c0]

&{Sheet1!$E$5:$G$7 NamedRange3       0 0 false false false false false false}
&{Sheet1!$E$5:$G$7 NamedRange3       0 0 false false false false false false}
&{Sheet1!$E$5:$G$7 NamedRange3       0 0 false false false false false false}

**Memory addresses and values after fix:**
[0xc820136280 0xc820136318 0xc8201363b0]

&{Sheet1!$A$1:$C$2 NamedRange1       0 0 false false false false false false}
&{Sheet1!$E$1:$G$2 NamedRange2       0 0 false false false false false false}
&{Sheet1!$E$5:$G$7 NamedRange3       0 0 false false false false false false}