### PR TITLE
stylistic changes

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -103,11 +103,7 @@ func (c *Cell) SetFloatWithFormat(n float64, format string) {
 	c.cellType = CellTypeNumeric
 }
 
-var timeLocationUTC *time.Location
-
-func init() {
-	timeLocationUTC, _ = time.LoadLocation("UTC")
-}
+var timeLocationUTC, _ = time.LoadLocation("UTC")
 
 func timeToUTCTime(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), timeLocationUTC)
@@ -161,7 +157,7 @@ func (c *Cell) Int64() (int64, error) {
 
 // SetInt sets a cell's value to an integer.
 func (c *Cell) SetInt(n int) {
-	c.Value = fmt.Sprintf("%d", n)
+	c.Value = strconv.Itoa(n)
 	c.NumFmt = builtInNumFmt[builtInNumFmtIndex_INT]
 	c.formula = ""
 	c.cellType = CellTypeNumeric
@@ -169,36 +165,28 @@ func (c *Cell) SetInt(n int) {
 
 // SetInt sets a cell's value to an integer.
 func (c *Cell) SetValue(n interface{}) {
-	var s string
-	switch n.(type) {
+	switch t := n.(type) {
 	case time.Time:
-		c.SetDateTime(n.(time.Time))
-		return
+		c.SetDateTime(t)
 	case int:
 		c.setGeneral(fmt.Sprintf("%v", n))
-		return
 	case int32:
 		c.setGeneral(fmt.Sprintf("%v", n))
-		return
 	case int64:
 		c.setGeneral(fmt.Sprintf("%v", n))
-		return
 	case float32:
 		c.setGeneral(fmt.Sprintf("%v", n))
-		return
 	case float64:
 		c.setGeneral(fmt.Sprintf("%v", n))
-		return
 	case string:
-		s = n.(string)
+		c.SetString(t)
 	case []byte:
-		s = string(n.([]byte))
+		c.SetString(string(t))
 	case nil:
-		s = ""
+		c.SetString("")
 	default:
-		s = fmt.Sprintf("%v", n)
+		c.SetString(fmt.Sprintf("%v", n))
 	}
-	c.SetString(s)
 }
 
 // SetInt sets a cell's value to an integer.

--- a/file_test.go
+++ b/file_test.go
@@ -245,13 +245,11 @@ func (l *FileSuite) TestAddSheet(c *C) {
 
 // Test that AddSheet returns an error if you try to add two sheets with the same name
 func (l *FileSuite) TestAddSheetWithDuplicateName(c *C) {
-	var f *File
-
-	f = NewFile()
+	f := NewFile()
 	_, err := f.AddSheet("MySheet")
 	c.Assert(err, IsNil)
 	_, err = f.AddSheet("MySheet")
-	c.Assert(err, ErrorMatches, "Duplicate sheet name 'MySheet'.")
+	c.Assert(err, ErrorMatches, "duplicate sheet name 'MySheet'.")
 }
 
 // Test that we can get the Nth sheet

--- a/lib.go
+++ b/lib.go
@@ -684,7 +684,7 @@ func readSheetsFromZipFile(f *zip.File, file *File, sheetXMLMap map[string]strin
 	}
 	file.Date1904 = workbook.WorkbookPr.Date1904
 
-	for entryNum, _ := range workbook.DefinedNames.DefinedName {
+	for entryNum := range workbook.DefinedNames.DefinedName {
 		file.DefinedNames = append(file.DefinedNames, &workbook.DefinedNames.DefinedName[entryNum])
 	}
 

--- a/style.go
+++ b/style.go
@@ -104,14 +104,10 @@ type Border struct {
 
 func NewBorder(left, right, top, bottom string) *Border {
 	return &Border{
-		Left:        left,
-		LeftColor:   "",
-		Right:       right,
-		RightColor:  "",
-		Top:         top,
-		TopColor:    "",
-		Bottom:      bottom,
-		BottomColor: "",
+		Left:   left,
+		Right:  right,
+		Top:    top,
+		Bottom: bottom,
 	}
 }
 
@@ -124,7 +120,11 @@ type Fill struct {
 }
 
 func NewFill(patternType, fgColor, bgColor string) *Fill {
-	return &Fill{PatternType: patternType, FgColor: fgColor, BgColor: bgColor}
+	return &Fill{
+		PatternType: patternType,
+		FgColor:     fgColor,
+		BgColor:     bgColor,
+	}
 }
 
 type Font struct {
@@ -151,13 +151,8 @@ type Alignment struct {
 	WrapText     bool
 }
 
-var defaultFontSize int
-var defaultFontName string
-
-func init() {
-	defaultFontSize = 12
-	defaultFontName = "Verdana"
-}
+var defaultFontSize = 12
+var defaultFontName = "Verdana"
 
 func SetDefaultFont(size int, name string) {
 	defaultFontSize = size
@@ -179,12 +174,7 @@ func DefaultBorder() *Border {
 
 func DefaultAlignment() *Alignment {
 	return &Alignment{
-		Horizontal:   "general",
-		Indent:       0,
-		ShrinkToFit:  false,
-		TextRotation: 0,
-		Vertical:     "bottom",
-		WrapText:     false,
+		Horizontal: "general",
+		Vertical:   "bottom",
 	}
-
 }


### PR DESCRIPTION
@tealeg: Love this library. 

I was using it again at work and noticed a fair amount of the code doesn't necessarily adhere to [typical Go conventions](https://github.com/golang/go/wiki/CodeReviewComments).

There's still a bunch more to clean up, but I figured I'd submit this to make sure you want it before I spend more time.

Most changes are things like returning literals, removing redundant declarations (e.g., `var x int = 0` which could just be `var x int`), and moving variables closer to their use (seemed very C-like to me).
