### PR TITLE
Fix prefix check for getExtent for merged cells

### DIFF
--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -253,7 +253,7 @@ func (mc *xlsxMergeCells) getExtent(cellRef string) (int, int, error) {
 		return 0, 0, nil
 	}
 	for _, cell := range mc.Cells {
-		if strings.HasPrefix(cell.Ref, cellRef) {
+		if strings.HasPrefix(cell.Ref, cellRef+":") {
 			parts := strings.Split(cell.Ref, ":")
 			startx, starty, err := getCoordsFromCellIDString(parts[0])
 			if err != nil {

--- a/xmlWorksheet_test.go
+++ b/xmlWorksheet_test.go
@@ -188,11 +188,16 @@ func (w *WorksheetSuite) TestUnmarshallWorksheetWithMergeCells(c *C) {
 // MergeCells.getExtents returns the horizontal and vertical extent of
 // a merge that begins at a given reference.
 func (w *WorksheetSuite) TestMergeCellsGetExtent(c *C) {
-	mc := xlsxMergeCells{Count: 1}
-	mc.Cells = make([]xlsxMergeCell, 1)
-	mc.Cells[0] = xlsxMergeCell{Ref: "A1:B5"}
+	mc := xlsxMergeCells{Count: 2}
+	mc.Cells = make([]xlsxMergeCell, 2)
+	mc.Cells[0] = xlsxMergeCell{Ref: "A11:A12"}
+	mc.Cells[1] = xlsxMergeCell{Ref: "A1:C5"}
 	h, v, err := mc.getExtent("A1")
 	c.Assert(err, IsNil)
-	c.Assert(h, Equals, 1)
+	c.Assert(h, Equals, 2)
 	c.Assert(v, Equals, 4)
+	h, v, err = mc.getExtent("A11")
+	c.Assert(err, IsNil)
+	c.Assert(h, Equals, 0)
+	c.Assert(v, Equals, 1)
 }


### PR DESCRIPTION
When doing prefix checking in getExtent for merged cells, need to stick `:` to the reference,
otherwise getExtent can return wrong info for a non merged cell A1 if there is a merged cell at A1n.
this would possibly close these two issues: https://github.com/tealeg/xlsx/issues/230 https://github.com/tealeg/xlsx/issues/212