### PR TITLE
Panic: runtime error: slice bounds out of range

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -379,7 +379,7 @@ func formulaForCell(rawcell xlsxC, sharedFormulas map[int]sharedFormula) string 
 					}
 				}
 				if start < len(orig) {
-					res += string(orig[start:end])
+					res += string(orig[start:])
 				}
 			}
 		}

--- a/lib_test.go
+++ b/lib_test.go
@@ -1191,6 +1191,13 @@ func (l *LibSuite) TestSharedFormulasWithAbsoluteReferences(c *C) {
 		"A1+$B$1",
 		"$A$1+$B$1",
 		`IF(C23>=E$12,"Q4",IF(C23>=$D$12,"Q3",IF(C23>=C$12,"Q2","Q1")))`,
+		`SUM(D44:H44)*IM_A_DEFINED_NAME`,
+		`IM_A_DEFINED_NAME+SUM(D44:H44)*IM_A_DEFINED_NAME_ALSO`,
+		`SUM(D44:H44)*IM_A_DEFINED_NAME+A1`,
+		"AA1",
+		"$AA1",
+		"AA$1",
+		"$AA$1",
 	}
 
 	expected := []string{
@@ -1206,6 +1213,13 @@ func (l *LibSuite) TestSharedFormulasWithAbsoluteReferences(c *C) {
 		"B2+$B$1",
 		"$A$1+$B$1",
 		`IF(D24>=F$12,"Q4",IF(D24>=$D$12,"Q3",IF(D24>=D$12,"Q2","Q1")))`,
+		`SUM(E45:I45)*IM_A_DEFINED_NAME`,
+		`IM_A_DEFINED_NAME+SUM(E45:I45)*IM_A_DEFINED_NAME_ALSO`,
+		`SUM(E45:I45)*IM_A_DEFINED_NAME+B2`,
+		"AB2",
+		"$AA2",
+		"AB$1",
+		"$AA$1",
 	}
 
 	anchorCell := "C4"


### PR DESCRIPTION
### Problem / Feature  

This is the fix for the panic when a shared formula contains a defined name.  For example, SUM(D44:H44)*IM_A_DEFINED_NAME

### Reviewers  

Please review @tealeg Thanks!
