### PR TITLE
Add support for code coverage (codecov.io) and update Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
 .DS_Store
 xlsx.test
 *.swp
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,13 @@ install:
   - go get -d -t -v ./... && go build -v ./...
 
 go:
-  - 1.2
-  - 1.3
+  - 1.5
+  - 1.6
+  - tip
+
+script:
+  - go vet ./...
+  - go test -v -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.org
+++ b/README.org
@@ -1,6 +1,9 @@
 * XLSX
 
+[[https://travis-ci.org/tealeg/xlsx][https://img.shields.io/travis/tealeg/xlsx/master.svg?style=flat-square]]
+[[https://codecov.io/gh/tealeg/xlsx][https://codecov.io/gh/tealeg/xlsx/branch/master/graph/badge.svg]]
 [[https://godoc.org/github.com/tealeg/xlsx][https://godoc.org/github.com/tealeg/xlsx?status.svg]]
+[[https://github.com/tealeg/xlsx#license][https://img.shields.io/badge/license-bsd-orange.svg]]
 
 ** Introduction
 xlsx is a library to simplify reading and writing the XML format used


### PR DESCRIPTION
Changes:
- .travis.yml:
  - bump go versions to 1.5 & 1.6
  - add `go vet`
  - add go test coverage
- README.org:
  -  add badges for travis, code coverage (codecov) and license
- .gitignore:
  - add "coverage.txt"

In order to use Codecov, you need to sign up first. It is straight forward: just [sign up with GitHub](https://codecov.io/login/github) and then add the repository that you wish to monitor. The service, like Travis, is free for open source projects. The biggest benefit of codecov is that it supports branch coverage whereas Coveralls does not. Codecov also has a [browser plugin](https://codecov.io/#features) that overlays code coverage on diffs and files.