### PR TITLE
fix pointer to slice check panic on WriteSlice

### DIFF
--- a/write.go
+++ b/write.go
@@ -14,12 +14,18 @@ func (r *Row) WriteSlice(e interface{}, cols int) int {
 		return cols
 	}
 
-	// it's a slice, so open up its values
-	v := reflect.ValueOf(e).Elem()
-	if v.Kind() != reflect.Slice { // is 'e' even a slice?
+	// make sure 'e' is a Ptr to Slice
+	v := reflect.ValueOf(e)
+	if v.Kind() != reflect.Ptr {
 		return -1
 	}
 
+	v = v.Elem()
+	if v.Kind() != reflect.Slice {
+		return -1
+	}
+
+	// it's a slice, so open up its values
 	n := v.Len()
 	if cols < n && cols > 0 {
 		n = cols

--- a/write_test.go
+++ b/write_test.go
@@ -154,4 +154,14 @@ func (r *RowSuite) TestWriteSlice(c *C) {
 	} else {
 		c.Assert(val, Equals, "Pointer to Stringer")
 	}
+
+	s7 := "expects -1 on non pointer to slice"
+	row7 := sheet.AddRow()
+	c.Assert(row7, NotNil)
+	s7_ret := row7.WriteSlice(s7, -1)
+	c.Assert(s7_ret, Equals, -1)
+	s7_ret = row7.WriteSlice(&s7, -1)
+	c.Assert(s7_ret, Equals, -1)
+	s7_ret = row7.WriteSlice([]string{s7}, -1)
+	c.Assert(s7_ret, Equals, -1)
 }


### PR DESCRIPTION
@tealeg I think this would be a right fix to #237 #238 
the panic is caused by calling Elem on non Ptr kind value,
this fix makes sure the value is a Ptr before calling Elem