### PR TITLE
Expose GetCoordsFromCellIDString & GetCellIDStringFromCoords

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -162,10 +162,10 @@ func intOnlyMapF(rune rune) rune {
 	return -1
 }
 
-// getCoordsFromCellIDString returns the zero based cartesian
+// GetCoordsFromCellIDString returns the zero based cartesian
 // coordinates from a cell name in Excel format, e.g. the cellIDString
 // "A1" returns 0, 0 and the "B3" return 1, 2.
-func getCoordsFromCellIDString(cellIDString string) (x, y int, error error) {
+func GetCoordsFromCellIDString(cellIDString string) (x, y int, error error) {
 	var letterPart string = strings.Map(letterOnlyMapF, cellIDString)
 	y, error = strconv.Atoi(strings.Map(intOnlyMapF, cellIDString))
 	if error != nil {
@@ -176,9 +176,9 @@ func getCoordsFromCellIDString(cellIDString string) (x, y int, error error) {
 	return x, y, error
 }
 
-// getCellIDStringFromCoords returns the Excel format cell name that
+// GetCellIDStringFromCoords returns the Excel format cell name that
 // represents a pair of zero based cartesian coordinates.
-func getCellIDStringFromCoords(x, y int) string {
+func GetCellIDStringFromCoords(x, y int) string {
 	letterPart := numericToLetters(x)
 	numericPart := y + 1
 	return fmt.Sprintf("%s%d", letterPart, numericPart)
@@ -191,7 +191,7 @@ func getCellIDStringFromCoords(x, y int) string {
 func getMaxMinFromDimensionRef(ref string) (minx, miny, maxx, maxy int, err error) {
 	var parts []string
 	parts = strings.Split(ref, ":")
-	minx, miny, err = getCoordsFromCellIDString(parts[0])
+	minx, miny, err = GetCoordsFromCellIDString(parts[0])
 	if err != nil {
 		return -1, -1, -1, -1, err
 	}
@@ -199,7 +199,7 @@ func getMaxMinFromDimensionRef(ref string) (minx, miny, maxx, maxy int, err erro
 		maxx, maxy = minx, miny
 		return
 	}
-	maxx, maxy, err = getCoordsFromCellIDString(parts[1])
+	maxx, maxy, err = GetCoordsFromCellIDString(parts[1])
 	if err != nil {
 		return -1, -1, -1, -1, err
 	}
@@ -220,7 +220,7 @@ func calculateMaxMinFromWorksheet(worksheet *xlsxWorksheet) (minx, miny, maxx, m
 	maxx = 0
 	for _, row := range worksheet.SheetData.Row {
 		for _, cell := range row.C {
-			x, y, err = getCoordsFromCellIDString(cell.R)
+			x, y, err = GetCoordsFromCellIDString(cell.R)
 			if err != nil {
 				return -1, -1, -1, -1, err
 			}
@@ -285,7 +285,7 @@ func makeRowFromRaw(rawrow xlsxRow, sheet *Sheet) *Row {
 
 	for _, rawcell := range rawrow.C {
 		if rawcell.R != "" {
-			x, _, error := getCoordsFromCellIDString(rawcell.R)
+			x, _, error := GetCoordsFromCellIDString(rawcell.R)
 			if error != nil {
 				panic(fmt.Sprintf("Invalid Cell Coord, %s\n", rawcell.R))
 			}
@@ -329,7 +329,7 @@ func formulaForCell(rawcell xlsxC, sharedFormulas map[int]sharedFormula) string 
 		return ""
 	}
 	if f.T == "shared" {
-		x, y, err := getCoordsFromCellIDString(rawcell.R)
+		x, y, err := GetCoordsFromCellIDString(rawcell.R)
 		if err != nil {
 			res = f.Content
 		} else {
@@ -392,7 +392,7 @@ func formulaForCell(rawcell xlsxC, sharedFormulas map[int]sharedFormula) string 
 // shiftCell returns the cell shifted according to dx and dy taking into consideration of absolute
 // references with dollar sign ($)
 func shiftCell(cellID string, dx, dy int) string {
-	fx, fy, _ := getCoordsFromCellIDString(cellID)
+	fx, fy, _ := GetCoordsFromCellIDString(cellID)
 
 	// Is fixed column?
 	fixedCol := strings.Index(cellID, "$") == 0
@@ -411,7 +411,7 @@ func shiftCell(cellID string, dx, dy int) string {
 	}
 
 	// New shifted cell
-	shiftedCellID := getCellIDStringFromCoords(fx, fy)
+	shiftedCellID := GetCellIDStringFromCoords(fx, fy)
 
 	if !fixedCol && !fixedRow {
 		return shiftedCellID
@@ -575,7 +575,7 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet) ([]*R
 			if err != nil {
 				panic(err.Error())
 			}
-			x, _, _ := getCoordsFromCellIDString(rawcell.R)
+			x, _, _ := GetCoordsFromCellIDString(rawcell.R)
 
 			// K1000000: Prevent panic when the range specified in the spreadsheet
 			//           view exceeds the actual number of columns in the dataset.

--- a/lib_test.go
+++ b/lib_test.go
@@ -160,15 +160,15 @@ func (l *LibSuite) TestGetCoordsFromCellIDString(c *C) {
 	var cellIDString string = "A3"
 	var x, y int
 	var err error
-	x, y, err = getCoordsFromCellIDString(cellIDString)
+	x, y, err = GetCoordsFromCellIDString(cellIDString)
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, 0)
 	c.Assert(y, Equals, 2)
 }
 
 func (l *LibSuite) TestGetCellIDStringFromCoords(c *C) {
-	c.Assert(getCellIDStringFromCoords(0, 0), Equals, "A1")
-	c.Assert(getCellIDStringFromCoords(2, 2), Equals, "C3")
+	c.Assert(GetCellIDStringFromCoords(0, 0), Equals, "A1")
+	c.Assert(GetCellIDStringFromCoords(2, 2), Equals, "C3")
 }
 
 func (l *LibSuite) TestGetMaxMinFromDimensionRef(c *C) {
@@ -1227,7 +1227,7 @@ func (l *LibSuite) TestSharedFormulasWithAbsoluteReferences(c *C) {
 	anchorCell := "C4"
 
 	sharedFormulas := map[int]sharedFormula{}
-	x, y, _ := getCoordsFromCellIDString(anchorCell)
+	x, y, _ := GetCoordsFromCellIDString(anchorCell)
 	for i, formula := range formulas {
 		res := formula
 		sharedFormulas[i] = sharedFormula{x, y, res}

--- a/sheet.go
+++ b/sheet.go
@@ -147,7 +147,7 @@ func (s *Sheet) handleMerged() {
 		mainstyle.Border.Right = "none"
 		mainstyle.Border.Bottom = "none"
 
-		maincol, mainrow, _ := getCoordsFromCellIDString(key)
+		maincol, mainrow, _ := GetCoordsFromCellIDString(key)
 		for rownum := 0; rownum <= cell.VMerge; rownum++ {
 			for colnum := 0; colnum <= cell.HMerge; colnum++ {
 				tmpcell := s.Cell(mainrow+rownum, maincol+colnum)

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -255,11 +255,11 @@ func (mc *xlsxMergeCells) getExtent(cellRef string) (int, int, error) {
 	for _, cell := range mc.Cells {
 		if strings.HasPrefix(cell.Ref, cellRef+":") {
 			parts := strings.Split(cell.Ref, ":")
-			startx, starty, err := getCoordsFromCellIDString(parts[0])
+			startx, starty, err := GetCoordsFromCellIDString(parts[0])
 			if err != nil {
 				return -1, -1, err
 			}
-			endx, endy, err := getCoordsFromCellIDString(parts[1])
+			endx, endy, err := GetCoordsFromCellIDString(parts[1])
 			if err != nil {
 				return -2, -2, err
 			}


### PR DESCRIPTION
This PR exposes `GetCoordsFromCellIDString` & `GetCellIDStringFromCoords` for public consumption. These are useful functions and have excel related use cases outside the internals of this package.

For example I'm using `GetCellIDStringFromCoords` to calculate the `Pane.TopLeftCell` value.