### PR TITLE
xlsxCol.CustomWidth should be boolean, not int.

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -233,11 +233,13 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 		}
 		colsXfIdList[c] = XfId
 
-		var customWidth int
+		var customWidth bool
 		if col.Width == 0 {
 			col.Width = ColWidth
+			customWidth = false
+			
 		} else {
-			customWidth = 1
+			customWidth = true
 		}
 		worksheet.Cols.Col = append(worksheet.Cols.Col,
 			xlsxCol{Min: col.Min,

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -162,7 +162,7 @@ func (s *SheetSuite) TestMakeXLSXSheetDefaultsCustomColWidth(c *C) {
 	refTable := NewSharedStringRefTable()
 	styles := newXlsxStyleSheet(nil)
 	worksheet := sheet.makeXLSXSheet(refTable, styles)
-	c.Assert(worksheet.Cols.Col[0].CustomWidth, Equals, 0)
+	c.Assert(worksheet.Cols.Col[0].CustomWidth, Equals, false)
 }
 
 // If the column width is customised, the xslxCol.CustomWidth field is set to 1.
@@ -178,7 +178,7 @@ func (s *SheetSuite) TestMakeXLSXSheetSetsCustomColWidth(c *C) {
 	refTable := NewSharedStringRefTable()
 	styles := newXlsxStyleSheet(nil)
 	worksheet := sheet.makeXLSXSheet(refTable, styles)
-	c.Assert(worksheet.Cols.Col[1].CustomWidth, Equals, 1)
+	c.Assert(worksheet.Cols.Col[1].CustomWidth, Equals, true)
 }
 
 func (s *SheetSuite) TestMarshalSheet(c *C) {

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -202,7 +202,7 @@ type xlsxCol struct {
 	Min          int     `xml:"min,attr"`
 	Style        int     `xml:"style,attr"`
 	Width        float64 `xml:"width,attr"`
-	CustomWidth  int     `xml:"customWidth,attr,omitempty"`
+	CustomWidth  bool    `xml:"customWidth,attr,omitempty"`
 	OutlineLevel uint8   `xml:"outlineLevel,attr,omitempty"`
 }
 


### PR DESCRIPTION
According to the standard, this field is a boolean, not an integer (as is currently set).  Without this change correct XLSX files fail on strconv.ParseInt.  

Fixes #275 