### PR TITLE
TimeToExcelTime is tuncating time to second

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -119,7 +119,7 @@ func TimeToUTCTime(t time.Time) time.Time {
 }
 
 func TimeToExcelTime(t time.Time) float64 {
-	return float64(t.Unix())/86400.0 + 25569.0
+	return float64(t.UnixNano())/8.64e13 + 25569.0
 }
 
 // SetDate sets the value of a cell to a float.


### PR DESCRIPTION
For my daily work, I have to track events with a precision higher than a second. The current implementation of TimeToExcelTime uses time.Unix, a function that returns explicitly a number of second. 

By using time.UnixNano and changing the divisor, the time stored in the Cell keeps its full precision.