### PR TITLE
Add function "SetHeight".

### DIFF
--- a/row.go
+++ b/row.go
@@ -9,6 +9,11 @@ type Row struct {
 	isCustom     bool
 }
 
+func (r *Row) SetHeight(ht float64) {
+	r.Height = ht
+	r.isCustom = true
+}
+
 func (r *Row) SetHeightCM(ht float64) {
 	r.Height = ht * 28.3464567 // Convert CM to postscript points
 	r.isCustom = true


### PR DESCRIPTION
When setting the height of a row equal to another, I have no idea but to use:
`row.SetHeightCM(sheet.Rows[0].Height / 28.3464567)`

So I think a function of setting row's height directly is necessary.