### PR TITLE
WIP: MergeCells: Optimization for large sheets.

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -334,6 +334,7 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 					worksheet.MergeCells = &xlsxMergeCells{}
 				}
 				worksheet.MergeCells.Cells = append(worksheet.MergeCells.Cells, mc)
+				worksheet.MergeCells.CellsMap[start] = mc
 			}
 		}
 		xSheet.Row = append(xSheet.Row, xRow)

--- a/sheet.go
+++ b/sheet.go
@@ -330,9 +330,6 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 				endrow := r + cell.VMerge + 1
 				end := fmt.Sprintf("%s%d", numericToLetters(endcol), endrow)
 				mc.Ref = start + ":" + end
-				if worksheet.MergeCells == nil {
-					worksheet.MergeCells = &xlsxMergeCells{}
-				}
 				worksheet.MergeCells.Cells = append(worksheet.MergeCells.Cells, mc)
 				worksheet.MergeCells.CellsMap[start] = mc
 			}

--- a/xmlWorkbook.go
+++ b/xmlWorkbook.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 )
 
 const (
@@ -198,6 +199,11 @@ func getWorksheetFromSheet(sheet xlsxSheet, worksheets map[string]*zip.File, she
 	error = decoder.Decode(worksheet)
 	if error != nil {
 		return nil, error
+	}
+	worksheet.MergeCells.CellsMap = make(map[string]xlsxMergeCell)
+	for _, cell := range worksheet.MergeCells.Cells {
+		cellRefs := strings.Split(cell.Ref, ":")
+		worksheet.MergeCells.CellsMap[cellRefs[0]] = cell
 	}
 	return worksheet, nil
 }

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -246,9 +246,10 @@ type xlsxMergeCell struct {
 }
 
 type xlsxMergeCells struct {
-	XMLName xml.Name        //`xml:"mergeCells,omitempty"`
-	Count   int             `xml:"count,attr,omitempty"`
-	Cells   []xlsxMergeCell `xml:"mergeCell,omitempty"`
+	XMLName  xml.Name        //`xml:"mergeCells,omitempty"`
+	Count    int             `xml:"count,attr,omitempty"`
+	Cells    []xlsxMergeCell `xml:"mergeCell,omitempty"`
+	CellsMap map[string]xlsxMergeCell
 }
 
 // Return the cartesian extent of a merged cell range from its origin
@@ -257,19 +258,17 @@ func (mc *xlsxMergeCells) getExtent(cellRef string) (int, int, error) {
 	if mc == nil {
 		return 0, 0, nil
 	}
-	for _, cell := range mc.Cells {
-		if strings.HasPrefix(cell.Ref, cellRef+":") {
-			parts := strings.Split(cell.Ref, ":")
-			startx, starty, err := GetCoordsFromCellIDString(parts[0])
-			if err != nil {
-				return -1, -1, err
-			}
-			endx, endy, err := GetCoordsFromCellIDString(parts[1])
-			if err != nil {
-				return -2, -2, err
-			}
-			return endx - startx, endy - starty, nil
+	if cell, ok := mc.CellsMap[cellRef]; ok {
+		parts := strings.Split(cell.Ref, ":")
+		startx, starty, err := GetCoordsFromCellIDString(parts[0])
+		if err != nil {
+			return -1, -1, err
 		}
+		endx, endy, err := GetCoordsFromCellIDString(parts[1])
+		if err != nil {
+			return -2, -2, err
+		}
+		return endx - startx, endy - starty, nil
 	}
 	return 0, 0, nil
 }


### PR DESCRIPTION
This patch fixes #312 (https://github.com/tealeg/xlsx/issues/312)
by removing an unneeded loop in `xmlWorksheet.getExtent` which,
for large excel sheets, iterates an excessive amount searching for
the desired merge cell via string operations and a for loop.

By adding a map to the `xlsxMergeCells` struct which stores the same
data as the `Cells` the patch preserves backwards compatibility for
any users of the library making use of that struct while also
allowing the `getExtent` function to simply use the cell reference
as a key to locate the appropriate cell.

This does not change the API in any way besides the addition of the
field to the `xlsxMergeCells` struct, so the existing test cases
should cover this.

Signed-off-by: Mark Stenglein <mark@stengle.in>