### PR TITLE
More improvements to cell formatting

### DIFF
--- a/cell_test.go
+++ b/cell_test.go
@@ -111,7 +111,7 @@ func (l *CellSuite) TestSetFloat(c *C) {
 	cell.SetFloat(0)
 	c.Assert(cell.Value, Equals, "0")
 	cell.SetFloat(0.000005)
-	c.Assert(cell.Value, Equals, "5e-06")
+	c.Assert(cell.Value, Equals, "0.000005")
 	cell.SetFloat(100.0)
 	c.Assert(cell.Value, Equals, "100")
 	cell.SetFloat(37947.75334343)
@@ -125,84 +125,84 @@ func (l *CellSuite) TestGeneralNumberHandling(c *C) {
 	// 1.1 will get you the same, with a stored value of 1.1000000000000001.
 	// Also, numbers greater than 1e11 and less than 1e-9 wil be shown as scientific notation.
 	testCases := []struct {
-		value                string
-		formattedValueOutput string
-		noExpValueOutput     string
+		value                   string
+		formattedValueOutput    string
+		noScientificValueOutput string
 	}{
 		{
-			value:                "18.989999999999998",
-			formattedValueOutput: "18.99",
-			noExpValueOutput:     "18.99",
+			value:                   "18.989999999999998",
+			formattedValueOutput:    "18.99",
+			noScientificValueOutput: "18.99",
 		},
 		{
-			value:                "1.1000000000000001",
-			formattedValueOutput: "1.1",
-			noExpValueOutput:     "1.1",
+			value:                   "1.1000000000000001",
+			formattedValueOutput:    "1.1",
+			noScientificValueOutput: "1.1",
 		},
 		{
-			value:                "0.0000000000000001",
-			formattedValueOutput: "1E-16",
-			noExpValueOutput:     "0.0000000000000001",
+			value:                   "0.0000000000000001",
+			formattedValueOutput:    "1E-16",
+			noScientificValueOutput: "0.0000000000000001",
 		},
 		{
-			value:                "0.000000000000008",
-			formattedValueOutput: "8E-15",
-			noExpValueOutput:     "0.000000000000008",
+			value:                   "0.000000000000008",
+			formattedValueOutput:    "8E-15",
+			noScientificValueOutput: "0.000000000000008",
 		},
 		{
-			value:                "1000000000000000000",
-			formattedValueOutput: "1E+18",
-			noExpValueOutput:     "1000000000000000000",
+			value:                   "1000000000000000000",
+			formattedValueOutput:    "1E+18",
+			noScientificValueOutput: "1000000000000000000",
 		},
 		{
-			value:                "1230000000000000000",
-			formattedValueOutput: "1.23E+18",
-			noExpValueOutput:     "1230000000000000000",
+			value:                   "1230000000000000000",
+			formattedValueOutput:    "1.23E+18",
+			noScientificValueOutput: "1230000000000000000",
 		},
 		{
-			value:                "12345678",
-			formattedValueOutput: "12345678",
-			noExpValueOutput:     "12345678",
+			value:                   "12345678",
+			formattedValueOutput:    "12345678",
+			noScientificValueOutput: "12345678",
 		},
 		{
-			value:                "0",
-			formattedValueOutput: "0",
-			noExpValueOutput:     "0",
+			value:                   "0",
+			formattedValueOutput:    "0",
+			noScientificValueOutput: "0",
 		},
 		{
-			value:                "-18.989999999999998",
-			formattedValueOutput: "-18.99",
-			noExpValueOutput:     "-18.99",
+			value:                   "-18.989999999999998",
+			formattedValueOutput:    "-18.99",
+			noScientificValueOutput: "-18.99",
 		},
 		{
-			value:                "-1.1000000000000001",
-			formattedValueOutput: "-1.1",
-			noExpValueOutput:     "-1.1",
+			value:                   "-1.1000000000000001",
+			formattedValueOutput:    "-1.1",
+			noScientificValueOutput: "-1.1",
 		},
 		{
-			value:                "-0.0000000000000001",
-			formattedValueOutput: "-1E-16",
-			noExpValueOutput:     "-0.0000000000000001",
+			value:                   "-0.0000000000000001",
+			formattedValueOutput:    "-1E-16",
+			noScientificValueOutput: "-0.0000000000000001",
 		},
 		{
-			value:                "-0.000000000000008",
-			formattedValueOutput: "-8E-15",
-			noExpValueOutput:     "-0.000000000000008",
+			value:                   "-0.000000000000008",
+			formattedValueOutput:    "-8E-15",
+			noScientificValueOutput: "-0.000000000000008",
 		},
 		{
-			value:                "-1000000000000000000",
-			formattedValueOutput: "-1E+18",
-			noExpValueOutput:     "-1000000000000000000",
+			value:                   "-1000000000000000000",
+			formattedValueOutput:    "-1E+18",
+			noScientificValueOutput: "-1000000000000000000",
 		},
 		{
-			value:                "-1230000000000000000",
-			formattedValueOutput: "-1.23E+18",
-			noExpValueOutput:     "-1230000000000000000",
+			value:                   "-1230000000000000000",
+			formattedValueOutput:    "-1.23E+18",
+			noScientificValueOutput: "-1230000000000000000",
 		},
 		{
-			value:                "-12345678",
-			formattedValueOutput: "-12345678",
-			noExpValueOutput:     "-12345678",
+			value:                   "-12345678",
+			formattedValueOutput:    "-12345678",
+			noScientificValueOutput: "-12345678",
 		},
 	}
 	for _, testCase := range testCases {
@@ -220,10 +220,115 @@ func (l *CellSuite) TestGeneralNumberHandling(c *C) {
 		if err != nil {
 			c.Fatal(err)
 		}
-		c.Assert(val, Equals, testCase.noExpValueOutput)
+		c.Assert(val, Equals, testCase.noScientificValueOutput)
 	}
 }
 
+// TestCellTypeFormatHandling tests all cell types other than numeric. Numeric cells are tested above since those
+// cells have so many edge cases.
+func (l *CellSuite) TestCellTypeFormatHandling(c *C) {
+	testCases := []struct {
+		cellType             CellType
+		numFmt               string
+		value                string
+		formattedValueOutput string
+		expectError          bool
+	}{
+		// All of the string cell types, will return only the string format if there is no @ symbol in the format.
+		{
+			cellType:             CellTypeInline,
+			numFmt:               `0;0;0;"Error"`,
+			value:                "asdf",
+			formattedValueOutput: "Error",
+		},
+		{
+			cellType:             CellTypeString,
+			numFmt:               `0;0;0;"Error"`,
+			value:                "asdf",
+			formattedValueOutput: "Error",
+		},
+		{
+			cellType:             CellTypeStringFormula,
+			numFmt:               `0;0;0;"Error"`,
+			value:                "asdf",
+			formattedValueOutput: "Error",
+		},
+		// Errors are returned as is regardless of what the format shows
+		{
+			cellType:             CellTypeError,
+			numFmt:               `0;0;0;"Error"`,
+			value:                "#NAME?",
+			formattedValueOutput: "#NAME?",
+		},
+		{
+			cellType:             CellTypeError,
+			numFmt:               `"$"@`,
+			value:                "#######",
+			formattedValueOutput: "#######",
+		},
+		// Dates are returned as is regardless of what the format shows
+		{
+			cellType:             CellTypeDate,
+			numFmt:               `"$"@`,
+			value:                "2017-10-24T15:29:30+00:00",
+			formattedValueOutput: "2017-10-24T15:29:30+00:00",
+		},
+		// Make sure the format used above would have done something for a string
+		{
+			cellType:             CellTypeString,
+			numFmt:               `"$"@`,
+			value:                "#######",
+			formattedValueOutput: "$#######",
+		},
+		// For bool cells, 0 is false, 1 is true, anything else will error
+		{
+			cellType:             CellTypeBool,
+			numFmt:               `"$"@`,
+			value:                "1",
+			formattedValueOutput: "TRUE",
+		},
+		{
+			cellType:             CellTypeBool,
+			numFmt:               `"$"@`,
+			value:                "0",
+			formattedValueOutput: "FALSE",
+		},
+		{
+			cellType:             CellTypeBool,
+			numFmt:               `"$"@`,
+			value:                "2",
+			expectError:          true,
+			formattedValueOutput: "2",
+		},
+		{
+			cellType:             CellTypeBool,
+			numFmt:               `"$"@`,
+			value:                "2",
+			expectError:          true,
+			formattedValueOutput: "2",
+		},
+		// Invalid cell type should cause an error
+		{
+			cellType:             CellType(7),
+			numFmt:               `0`,
+			value:                "1.0",
+			expectError:          true,
+			formattedValueOutput: "1.0",
+		},
+	}
+	for _, testCase := range testCases {
+		cell := Cell{
+			cellType: testCase.cellType,
+			NumFmt:   testCase.numFmt,
+			Value:    testCase.value,
+		}
+		val, err := cell.FormattedValue()
+		if err != nil != testCase.expectError {
+			c.Fatal(err)
+		}
+		c.Assert(val, Equals, testCase.formattedValueOutput)
+	}
+}
 func (s *CellSuite) TestGetTime(c *C) {
 	cell := Cell{}
 	cell.SetFloat(0)
@@ -508,13 +613,13 @@ func (s *CellSuite) TestSetterGetters(c *C) {
 	intValue, _ := cell.Int()
 	c.Assert(intValue, Equals, 1024)
 	c.Assert(cell.NumFmt, Equals, builtInNumFmt[builtInNumFmtIndex_GENERAL])
-	c.Assert(cell.Type(), Equals, CellTypeGeneral)
+	c.Assert(cell.Type(), Equals, CellTypeNumeric)
 
 	cell.SetInt64(1024)
 	int64Value, _ := cell.Int64()
 	c.Assert(int64Value, Equals, int64(1024))
 	c.Assert(cell.NumFmt, Equals, builtInNumFmt[builtInNumFmtIndex_GENERAL])
-	c.Assert(cell.Type(), Equals, CellTypeGeneral)
+	c.Assert(cell.Type(), Equals, CellTypeNumeric)
 
 	cell.SetFloat(1.024)
 	float, _ := cell.Float()
@@ -522,11 +627,15 @@ func (s *CellSuite) TestSetterGetters(c *C) {
 	c.Assert(float, Equals, 1.024)
 	c.Assert(intValue, Equals, 1)
 	c.Assert(cell.NumFmt, Equals, builtInNumFmt[builtInNumFmtIndex_GENERAL])
-	c.Assert(cell.Type(), Equals, CellTypeGeneral)
+	c.Assert(cell.Type(), Equals, CellTypeNumeric)
 
 	cell.SetFormula("10+20")
 	c.Assert(cell.Formula(), Equals, "10+20")
-	c.Assert(cell.Type(), Equals, CellTypeFormula)
+	c.Assert(cell.Type(), Equals, CellTypeNumeric)
+
+	cell.SetStringFormula("A1")
+	c.Assert(cell.Formula(), Equals, "A1")
+	c.Assert(cell.Type(), Equals, CellTypeStringFormula)
 }
 
 // TestOddInput is a regression test for #101. When the number format
@@ -587,6 +696,14 @@ func (s *CellSuite) TestSetValue(c *C) {
 		val, err := cell.Float()
 		c.Assert(err, IsNil)
 		c.Assert(val, Equals, 1.11)
+	}
+	// In the naive implementation using go fmt "%v", this test would fail and the cell.Value would be "1e-06"
+	for _, i := range []interface{}{0.000001, float32(0.000001), float64(0.000001)} {
+		cell.SetValue(i)
+		c.Assert(cell.Value, Equals, "0.000001")
+		val, err := cell.Float()
+		c.Assert(err, IsNil)
+		c.Assert(val, Equals, 0.000001)
 	}
 
 	// time

--- a/col.go
+++ b/col.go
@@ -15,22 +15,26 @@ type Col struct {
 	style        *Style
 }
 
+// SetType will set the format string of a column based on the type that you want to set it to.
+// This function does not really make a lot of sense.
 func (c *Col) SetType(cellType CellType) {
 	switch cellType {
 	case CellTypeString:
 		c.numFmt = builtInNumFmt[builtInNumFmtIndex_STRING]
-	case CellTypeBool:
-		c.numFmt = builtInNumFmt[builtInNumFmtIndex_GENERAL] //TEMP
 	case CellTypeNumeric:
 		c.numFmt = builtInNumFmt[builtInNumFmtIndex_INT]
-	case CellTypeDate:
-		c.numFmt = builtInNumFmt[builtInNumFmtIndex_DATE]
-	case CellTypeFormula:
-		c.numFmt = builtInNumFmt[builtInNumFmtIndex_GENERAL]
+	case CellTypeBool:
+		c.numFmt = builtInNumFmt[builtInNumFmtIndex_GENERAL] //TEMP
+	case CellTypeInline:
+		c.numFmt = builtInNumFmt[builtInNumFmtIndex_STRING]
 	case CellTypeError:
 		c.numFmt = builtInNumFmt[builtInNumFmtIndex_GENERAL] //TEMP
-	case CellTypeGeneral:
+	case CellTypeDate:
+		// Cells that are stored as dates are not properly supported in this library.
+		// They should instead be stored as a Numeric with a date format.
 		c.numFmt = builtInNumFmt[builtInNumFmtIndex_GENERAL]
+	case CellTypeStringFormula:
+		c.numFmt = builtInNumFmt[builtInNumFmtIndex_STRING]
 	}
 }
 

--- a/file.go
+++ b/file.go
@@ -50,8 +50,7 @@ func OpenFileWithRowLimit(fileName string, rowLimit int) (file *File, err error)
 	if err != nil {
 		return nil, err
 	}
-	file, err = ReadZipWithRowLimit(z, rowLimit)
-	return
+	return ReadZipWithRowLimit(z, rowLimit)
 }
 
 // OpenBinary() take bytes of an XLSX file and returns a populated

--- a/file_test.go
+++ b/file_test.go
@@ -937,7 +937,7 @@ func (l *FileSuite) TestReadWorkbookWithTypes(c *C) {
 	c.Assert(sheet.Rows[5].Cells[0].Bool(), Equals, true)
 
 	// formula
-	c.Assert(sheet.Rows[6].Cells[0].Type(), Equals, CellTypeFormula)
+	c.Assert(sheet.Rows[6].Cells[0].Type(), Equals, CellTypeNumeric)
 	c.Assert(sheet.Rows[6].Cells[0].Formula(), Equals, "10+20")
 	c.Assert(sheet.Rows[6].Cells[0].Value, Equals, "30")
 

--- a/lib_test.go
+++ b/lib_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"os"
-
 	"strings"
 
 	. "gopkg.in/check.v1"
@@ -1013,7 +1012,7 @@ func (l *LibSuite) TestReadRowsFromSheetWithMultipleTypes(c *C) {
 	c.Assert(cell4.Bool(), Equals, true)
 
 	cell5 := row.Cells[4]
-	c.Assert(cell5.Type(), Equals, CellTypeFormula)
+	c.Assert(cell5.Type(), Equals, CellTypeNumeric)
 	c.Assert(cell5.Formula(), Equals, "10+20")
 	c.Assert(cell5.Value, Equals, "30")
 


### PR DESCRIPTION
cc: @rck109d
With these final changes to cell formatting, the cell formatting is getting really good.
- Boolean and Error cells are now correctly formatted
- The CellTypes now match the actual possibilities from the XLSX spec
- CellTypeFormula was not a real type, formulas can be found in cells of any type (Except for strings which now have their own CellStringFormula type)
- CellTypeGeneral was also not a real type, cells can have a number format string of "general" with any of the cell types.
- CellTypeDate was being used for all dates, even though most dates are stored as Numeric cells with a number format string that has date formatting.
- Cells with formulas that return strings or bools are now round tripped correctly.
- Small floats are now marshaled to XML correctly, previously they were marshaled in scientific notation which is not a valid way to store numbers in XML.

Things still stopping formatting from being perfect:
- Not all possible number formats are handled, still only the most common ones. Though many formatting features are handled in a generic way, so the number of supported number formats right now is very, very large.
- Date format strings are not handled correctly at all, though they are detected correctly.
- Format strings that specify different formats based on the value of the number are still not supported (eg "[<100][red]0;[black]0", which means numbers less than 100 are red, other numbers are black.) These formats are assumed to be the "positive;negative;zero;string" format, so something pretty close to correct will still happen, especially since these formats tend to only change the color.
- Phone number and Social Security number formats are not supported because they put literal dashes in between the different number format digits, which is pretty tricky to handle in a generic way.