### PR TITLE
fix bug "no read alignment property RotationText"

### DIFF
--- a/xmlStyle.go
+++ b/xmlStyle.go
@@ -211,9 +211,9 @@ func (styles *xlsxStyleSheet) getStyle(styleIndex int) *Style {
 			style.Alignment.Vertical = xf.Alignment.Vertical
 		}
 		style.Alignment.WrapText = xf.Alignment.WrapText
-        style.Alignment.TextRotation=xf.Alignment.TextRotation
+        	style.Alignment.TextRotation = xf.Alignment.TextRotation
 		
-        styles.Lock()
+        	styles.Lock()
 		styles.styleCache[styleIndex] = style
 		styles.Unlock()
 	}

--- a/xmlStyle.go
+++ b/xmlStyle.go
@@ -211,8 +211,9 @@ func (styles *xlsxStyleSheet) getStyle(styleIndex int) *Style {
 			style.Alignment.Vertical = xf.Alignment.Vertical
 		}
 		style.Alignment.WrapText = xf.Alignment.WrapText
-
-		styles.Lock()
+        style.Alignment.TextRotation=xf.Alignment.TextRotation
+		
+        styles.Lock()
 		styles.styleCache[styleIndex] = style
 		styles.Unlock()
 	}


### PR DESCRIPTION
When reading an Excel file, the property TextRotation is not used.
This request fix it.