### PR TITLE
Fixes #147 Prevent making files with null rows on open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.8.x
   - 1.9.x
-  - tip
 
 script:
   - go vet ./...

--- a/lib.go
+++ b/lib.go
@@ -505,7 +505,7 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet, rowLi
 	var rows []*Row
 	var cols []*Col
 	var row *Row
-	var minCol, maxCol, minRow, maxRow, colCount, rowCount int
+	var minCol, maxCol, maxRow, colCount, rowCount int
 	var reftable *RefTable
 	var err error
 	var insertRowIndex, insertColIndex int
@@ -516,9 +516,9 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet, rowLi
 	}
 	reftable = file.referenceTable
 	if len(Worksheet.Dimension.Ref) > 0 && len(strings.Split(Worksheet.Dimension.Ref, ":")) == 2 && rowLimit == NoRowLimit {
-		minCol, minRow, maxCol, maxRow, err = getMaxMinFromDimensionRef(Worksheet.Dimension.Ref)
+		minCol, _, maxCol, maxRow, err = getMaxMinFromDimensionRef(Worksheet.Dimension.Ref)
 	} else {
-		minCol, minRow, maxCol, maxRow, err = calculateMaxMinFromWorksheet(Worksheet)
+		minCol, _, maxCol, maxRow, err = calculateMaxMinFromWorksheet(Worksheet)
 	}
 	if err != nil {
 		panic(err.Error())
@@ -528,7 +528,6 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet, rowLi
 	colCount = maxCol + 1
 	rows = make([]*Row, rowCount)
 	cols = make([]*Col, colCount)
-	insertRowIndex = minRow
 	for i := range cols {
 		cols[i] = &Col{
 			Hidden: false,
@@ -557,11 +556,6 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet, rowLi
 				}
 			}
 		}
-	}
-
-	// insert leading empty rows that is in front of minRow
-	for rowIndex := 0; rowIndex < minRow; rowIndex++ {
-		rows[rowIndex] = makeEmptyRow(sheet)
 	}
 
 	numRows := len(rows)
@@ -632,6 +626,11 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File, sheet *Sheet, rowLi
 			rows[insertRowIndex] = row
 		}
 		insertRowIndex++
+	}
+
+	// insert trailing empty rows for the rest of the file
+	for ; insertRowIndex < maxRow; insertRowIndex++ {
+		rows[insertRowIndex] = makeEmptyRow(sheet)
 	}
 	return rows, cols, colCount, rowCount
 }


### PR DESCRIPTION
Some spreadsheet software will create files with omitted rows if those rows were empty. The code accounted for ones at the start and the middle, but not at the end of the file.

My code to use this library did not expect that entries in the Row array of a file could be null, and I think that is a reasonable assumption.

I've also removed 'tip' from the go versions that the tests will be run in. For some reason tip takes almost three times as long as the standard go versions, and we wouldn't even change anything if tip started failing. I removed it before, but I think there was a merge conflict with someone else modifying that file that lead to it coming back.