### PR TITLE
Stream writing with custom styles and types per row

### DIFF
--- a/file.go
+++ b/file.go
@@ -226,6 +226,14 @@ func replaceRelationshipsNameSpace(workbookMarshal string) string {
 	return strings.Replace(newWorkbook, oldXmlns, newXmlns, 1)
 }
 
+func (f *File) StyleSheet() *xlsxStyleSheet  {
+	if f.styles == nil {
+		f.styles = newXlsxStyleSheet(f.theme)
+		f.styles.reset()
+	}
+	return f.styles
+}
+
 // Construct a map of file name to XML content representing the file
 // in terms of the structure of an XLSX file.
 func (f *File) MarshallParts() (map[string]string, error) {
@@ -249,10 +257,8 @@ func (f *File) MarshallParts() (map[string]string, error) {
 	workbook = f.makeWorkbook()
 	sheetIndex := 1
 
-	if f.styles == nil {
-		f.styles = newXlsxStyleSheet(f.theme)
-	}
-	f.styles.reset()
+	f.StyleSheet()
+
 	if len(f.Sheets) == 0 {
 		err := errors.New("Workbook must contains atleast one worksheet")
 		return nil, err

--- a/stream_file_builder.go
+++ b/stream_file_builder.go
@@ -88,7 +88,7 @@ func NewStreamFileBuilderForPath(path string) (*StreamFileBuilder, error) {
 // AddSheet will add sheets with the given name with the provided headers. The headers cannot be edited later, and all
 // rows written to the sheet must contain the same number of cells as the header. Sheet names must be unique, or an
 // error will be thrown.
-func (sb *StreamFileBuilder) AddSheet(name string) error {
+func (sb *StreamFileBuilder) AddSheet(name string, headers []string, cellTypes []*CellType) error {
 	if sb.built {
 		return BuiltStreamFileBuilderError
 	}
@@ -100,6 +100,11 @@ func (sb *StreamFileBuilder) AddSheet(name string) error {
 		return err
 	}
 	sb.styleIds = append(sb.styleIds, []int{})
+
+	if headers != nil {
+		return sb.SetHeaders(headers, cellTypes)
+	}
+
 	return nil
 }
 

--- a/stream_file_builder.go
+++ b/stream_file_builder.go
@@ -140,11 +140,14 @@ func (sb *StreamFileBuilder) SetHeaders(headers []string, cellTypes []*CellType)
 	return nil
 }
 
-func (sb *StreamFileBuilder) AddStyle(style *Style, cellType CellType) int {
+func (sb *StreamFileBuilder) AddStyle(style *Style, cellType CellType) (int, error) {
+	if sb.built {
+		return 0, BuiltStreamFileBuilderError
+	}
 	styles := sb.xlsxFile.StyleSheet()
 	fmt, _ := cellTypeToNumFmtMap[cellType]
 	numFmt := styles.newNumFmt(fmt)
-	return handleStyleForXLSX(style, numFmt.NumFmtId, styles)
+	return handleStyleForXLSX(style, numFmt.NumFmtId, styles), nil
 }
 
 // Build begins streaming the XLSX file to the io, by writing all the XLSX metadata. It creates a StreamFile struct

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,7 +16,7 @@ const (
 
 type StreamSuite struct{}
 
-var _ = Suite(&SheetSuite{})
+var _ = Suite(&StreamSuite{})
 
 func (s *StreamSuite) TestTestsShouldMakeRealFilesShouldBeFalse(t *C) {
 	if TestsShouldMakeRealFiles {


### PR DESCRIPTION
Hello everyone!

I'm from NodeJS world, and we can't generate large XLSX files (500K+) in Javascript with high performance.

I was looking for a library that could do using stream, then I found tealeg/xlsx! 

But I needed to insert cells with style as stream, and at the moment it is only possible to set the type to collumns, before call the build method. 

I needed to create custom headers and rows with styles and types, and choose different styles and types per row. 

So I changed a few lines of code to achieve this. Here, a small example with the commented changes:

```
	// error handling was omitted for brevity
	file, err := xlsx.NewStreamFileBuilderForPath("stream.xlsx")

	// I allow AddSheet without headers (2nd parameter) and cellTypes (3rd parameter)
	err = file.AddSheet("sheetName1", nil, nil)

	boldStyle := xlsx.NewStyle()
	boldFont := xlsx.NewFont(10, "Arial")
	boldFont.Bold = true
	boldStyle.Font = *boldFont
	boldStyle.ApplyFont = true

	// I expose Sheet to allow insert and edit Cells, I used it to define custom headers.
	file.Sheet.AddRow().WriteSlice(&[]string{"a", "b", "c"}, -1)
	file.Sheet.Cell(0, 0).SetStyle(boldStyle)

	// Creating a style to be used in .WriteWithStyleFmtIds (when processing stream)
	redStyle := xlsx.NewStyle()
	font := xlsx.NewFont(10, "Arial")
	font.Color = "FFFF0000"
	redStyle.Font = *font
	redStyle.ApplyFont = true
	redStyleId := file.AddStyle(redStyle, xlsx.CellTypeNumeric)

	// Define style and cellType for colls and store in redStyleFmtIds
	redStyleFmtIds := &[]xlsx.StyleFmtId{
		{ redStyleId, xlsx.CellTypeNumeric },
		{ redStyleId, xlsx.CellTypeNumeric },
		{ redStyleId, xlsx.CellTypeString },
	}

	streamFile, err := file.Build()

	// Write row without style and types
	err = streamFile.Write([]string{"1", "2", "a string"})
	
	// Write row with style and use redStyleFmtIds
	err = streamFile.WriteWithStyleFmtIds([]string{"3", "4", "other string"}, redStyleFmtIds)

	err = streamFile.Close()
```

Please let me know if it is convenient to have some example of Stream in README, so I can write it.
