### PR TITLE
The length of "sheetName" is incorrectly determined utf-8 char

### DIFF
--- a/file.go
+++ b/file.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // File is a high level structure providing a slice of Sheet structs
@@ -154,8 +155,8 @@ func (f *File) AddSheet(sheetName string) (*Sheet, error) {
 	if _, exists := f.Sheet[sheetName]; exists {
 		return nil, fmt.Errorf("duplicate sheet name '%s'.", sheetName)
 	}
-	if len(sheetName) >= 31 {
-		return nil, fmt.Errorf("sheet name must be less than 31 characters long.  It is currently '%d' characters long", len(sheetName))
+	if utf8.RuneCountInString(sheetName) >= 31 {
+		return nil, fmt.Errorf("sheet name must be less than 31 characters long.  It is currently '%d' characters long", utf8.RuneCountInString(sheetName))
 	}
 	sheet := &Sheet{
 		Name:     sheetName,


### PR DESCRIPTION
When adding a new sheet, the length of "sheetName" is incorrectly determined if there are utf-8 characters