### PR TITLE
Fix documentation showing how to use read struct

### DIFF
--- a/example_read_test.go
+++ b/example_read_test.go
@@ -29,8 +29,8 @@ func ExampleRow_ReadStruct() {
 	readStruct := &structTest{}
 	err := row.ReadStruct(readStruct)
 	if err != nil {
-		fmt.Println(readStruct)
-	} else {
 		panic(err)
+	} else {
+		fmt.Println(readStruct)
 	}
 }

--- a/example_read_test.go
+++ b/example_read_test.go
@@ -30,7 +30,6 @@ func ExampleRow_ReadStruct() {
 	err := row.ReadStruct(readStruct)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println(readStruct)
 	}
+	fmt.Println(readStruct)
 }


### PR DESCRIPTION
While looking at the documentation for `ReadStruct` I've noticed [a typo in the example](https://godoc.org/github.com/tealeg/xlsx#example-Row-ReadStruct). The code is displaying the struct on error and throw a panic when no error.