### PR TITLE
sheet.row get row by index from sheet issue #388

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -56,6 +56,25 @@ func (s *Sheet) AddRow() *Row {
 	return row
 }
 
+// Make sure we always have as many Rows as we do cells.
+func (s *Sheet) maybeAddRow(rowCount int) {
+	if rowCount > s.MaxRow {
+		loopCnt := rowCount - s.MaxRow
+		for i := 0; i < loopCnt; i++ {
+
+			row := &Row{Sheet: s}
+			s.Rows = append(s.Rows, row)
+		}
+		s.MaxRow = rowCount
+	}
+}
+
+// Make sure we always have as many Rows as we do cells.
+func (s *Sheet) Row(idx int) *Row {
+	s.maybeAddRow(idx + 1)
+	return s.Rows[idx]
+}
+
 // Make sure we always have as many Cols as we do cells.
 func (s *Sheet) maybeAddCol(cellCount int) {
 	if cellCount > s.MaxCol {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -21,6 +21,19 @@ func (s *SheetSuite) TestAddRow(c *C) {
 	c.Assert(len(sheet.Rows), Equals, 1)
 }
 
+// Test we can get row by index from  Sheet
+func (s *SheetSuite) TestGetRowByIndex(c *C) {
+	var f *File
+	f = NewFile()
+	sheet, _ := f.AddSheet("MySheet")
+	row := sheet.Row(10)
+	c.Assert(row, NotNil)
+	c.Assert(len(sheet.Rows), Equals, 10)
+	row = sheet.Row(2)
+	c.Assert(row, NotNil)
+	c.Assert(len(sheet.Rows), Equals, 10)
+}
+
 func (s *SheetSuite) TestMakeXLSXSheetFromRows(c *C) {
 	file := NewFile()
 	sheet, _ := file.AddSheet("Sheet1")

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -28,10 +28,10 @@ func (s *SheetSuite) TestGetRowByIndex(c *C) {
 	sheet, _ := f.AddSheet("MySheet")
 	row := sheet.Row(10)
 	c.Assert(row, NotNil)
-	c.Assert(len(sheet.Rows), Equals, 10)
+	c.Assert(len(sheet.Rows), Equals, 11)
 	row = sheet.Row(2)
 	c.Assert(row, NotNil)
-	c.Assert(len(sheet.Rows), Equals, 10)
+	c.Assert(len(sheet.Rows), Equals, 11)
 }
 
 func (s *SheetSuite) TestMakeXLSXSheetFromRows(c *C) {


### PR DESCRIPTION
close #388 

Implement a similar sheet.Col method. Get a row by the index of row, if the row does not exist, add row

