### PR TITLE
Test for invalid characters in sheet name.

### DIFF
--- a/file.go
+++ b/file.go
@@ -158,6 +158,13 @@ func (f *File) AddSheet(sheetName string) (*Sheet, error) {
 	if utf8.RuneCountInString(sheetName) >= 31 {
 		return nil, fmt.Errorf("sheet name must be less than 31 characters long.  It is currently '%d' characters long", utf8.RuneCountInString(sheetName))
 	}
+	// Iterate over the runes
+	for _, r := range sheetName {
+		// Excel forbids : \ / ? * [ ]
+		if r == ':' || r == '\\' || r == '/' || r == '?' || r == '*' || r == '[' || r == ']' {
+			return nil, fmt.Errorf("sheet name must not contain any restricted characters : \\ / ? * [ ] but contains '%s'", string(r))
+		}
+	}
 	sheet := &Sheet{
 		Name:     sheetName,
 		File:     f,

--- a/file_test.go
+++ b/file_test.go
@@ -389,6 +389,15 @@ func (l *FileSuite) TestNthSheet(c *C) {
 	c.Assert(sheetByIndex, Equals, sheetByName)
 }
 
+// Test invalid sheet name characters
+func (l *FileSuite) TestInvalidSheetNameCharacters(c *C) {
+	f := NewFile()
+	for _, invalidChar := range []string{":", "\\", "/", "?", "*", "[", "]"} {
+		_, err := f.AddSheet(invalidChar)
+		c.Assert(err, NotNil)
+	}
+}
+
 // Test that we can create a Workbook and marshal it to XML.
 func (l *FileSuite) TestMarshalWorkbook(c *C) {
 	var f *File


### PR DESCRIPTION
Excel doesn't like certain characters `: \ / ? * [ ]` in the sheet name. This PR adds a check for these characters.

![Image of sheet name limits in Excel 2016](https://user-images.githubusercontent.com/72603/27325174-d9daa416-55a7-11e7-89f9-b27679f8bb52.png)

Fixes #407.