### PR TITLE
Add IsTime method to Cell.

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -100,6 +100,12 @@ func (c *Cell) SetFloat(n float64) {
 	c.SetValue(n)
 }
 
+// IsTime returns true if the cell stores a time value.
+func (c *Cell) IsTime() bool {
+	c.getNumberFormat()
+	return c.parsedNumFmt.isTimeFormat
+}
+
 //GetTime returns the value of a Cell as a time.Time
 func (c *Cell) GetTime(date1904 bool) (t time.Time, err error) {
 	f, err := c.Float()

--- a/cell_test.go
+++ b/cell_test.go
@@ -329,6 +329,19 @@ func (l *CellSuite) TestCellTypeFormatHandling(c *C) {
 		c.Assert(val, Equals, testCase.formattedValueOutput)
 	}
 }
+
+func (s *CellSuite) TestIsTime(c *C) {
+	cell := Cell{}
+	isTime := cell.IsTime()
+	c.Assert(isTime, Equals, false)
+	cell.Value = "43221"
+	c.Assert(isTime, Equals, false)
+	cell.NumFmt = "d-mmm-yy"
+	cell.Value = "43221"
+	isTime = cell.IsTime()
+	c.Assert(isTime, Equals, true)
+}
+
 func (s *CellSuite) TestGetTime(c *C) {
 	cell := Cell{}
 	cell.SetFloat(0)


### PR DESCRIPTION
Currently, there's no way to know if a cell stores a time or not, this brings problems if you want to use particular number format functions like `GeneralNumericWithoutScientific` instead of `String` or `FormattedValue`, as times will be smashed to a number.

A possible workaround is to try to parse it with `GetTime`, and see whether or not it returns an error. However, in `parsedNumFmt` is stored a convenient boolean value that can be exposed, without the waste of computational power of the use of `GetTime`.