### PR TITLE
Remove font warning from Apple Numbers

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -570,7 +570,7 @@ func (l *FileSuite) TestMarshalFile(c *C) {
         <a:font script="Geor" typeface="Sylfaen"/>
       </a:majorFont>
       <a:minorFont>
-        <a:latin typeface="Calibri"/>
+        <a:latin typeface="Arial"/>
         <a:ea typeface=""/>
         <a:cs typeface=""/>
         <a:font script="Jpan" typeface="ＭＳ Ｐゴシック"/>

--- a/templates.go
+++ b/templates.go
@@ -97,7 +97,7 @@ const TEMPLATE_XL_THEME_THEME = `<?xml version="1.0" encoding="UTF-8" standalone
         <a:font script="Geor" typeface="Sylfaen"/>
       </a:majorFont>
       <a:minorFont>
-        <a:latin typeface="Calibri"/>
+        <a:latin typeface="Arial"/>
         <a:ea typeface=""/>
         <a:cs typeface=""/>
         <a:font script="Jpan" typeface="ＭＳ Ｐゴシック"/>


### PR DESCRIPTION
Currently XLSX files created with this library will show a pop up when opened in Apple Numbers asking to replace a missing font. So I'm switching Calibri in the default theme for Arial.  According to this website, Arial is available on both PC and Mac.
https://www.macworld.com/article/1144660/xplatype.html