### PR TITLE
Add Go modules support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
+
+env:
+  - GO111MODULE=on
 
 script:
   - go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/tealeg/xlsx
+
+go 1.8
+
+require (
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Support for modules
This PR adds the `go.mod` and `go.sum` files needed to define dependencies in the new [Go modules system](https://github.com/golang/go/wiki/Modules).

### Travis CI
I also updated the Travis config file to work with modules.

### Steps to take after merging
After this has been merged, please [tag the latest commit with semver](https://github.com/golang/go/wiki/Modules#modules). Given that the last release was [v1.0.3](https://github.com/tealeg/xlsx/releases/tag/v1.0.3), something like `v1.1.0` sounds good to me.

---
If you have any questions around modules or regarding tagging, please don't hesitate to ask me.