### PR TITLE
add support of rich text

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -60,6 +60,7 @@ func (ct *CellType) fallbackTo(cellData string, fallback CellType) CellType {
 type Cell struct {
 	Row            *Row
 	Value          string
+	RichText       []RichTextRun
 	formula        string
 	style          *Style
 	NumFmt         string
@@ -155,6 +156,15 @@ func (c *Cell) Type() CellType {
 // SetString sets the value of a cell to a string.
 func (c *Cell) SetString(s string) {
 	c.Value = s
+	c.RichText = nil
+	c.formula = ""
+	c.cellType = CellTypeString
+}
+
+// SetRichText sets the value of a cell to a set of the rich text.
+func (c *Cell) SetRichText(r []RichTextRun) {
+	c.Value = ""
+	c.RichText = append([]RichTextRun(nil), r...)
 	c.formula = ""
 	c.cellType = CellTypeString
 }

--- a/format_code.go
+++ b/format_code.go
@@ -85,13 +85,19 @@ func (fullFormat *parsedNumberFormat) FormatValue(cell *Cell) (string, error) {
 	case CellTypeInline:
 		fallthrough
 	case CellTypeStringFormula:
+		var cellValue string
+		if len(cell.RichText) > 0 {
+			cellValue = richTextToPlainText(cell.RichText)
+		} else {
+			cellValue = cell.Value
+		}
 		textFormat := cell.parsedNumFmt.textFormat
 		// This switch statement is only for String formats
 		switch textFormat.reducedFormatString {
 		case builtInNumFmt[builtInNumFmtIndex_GENERAL]: // General is literally "general"
-			return cell.Value, nil
+			return cellValue, nil
 		case builtInNumFmt[builtInNumFmtIndex_STRING]: // String is "@"
-			return textFormat.prefix + cell.Value + textFormat.suffix, nil
+			return textFormat.prefix + cellValue + textFormat.suffix, nil
 		case "":
 			// If cell is not "General" and there is not an "@" symbol in the format, then the cell's value is not
 			// used when determining what to display. It would be completely legal to have a format of "Error"
@@ -99,7 +105,7 @@ func (fullFormat *parsedNumberFormat) FormatValue(cell *Cell) (string, error) {
 			// have a prefix of "Error" and a reduced format string of "" (empty string).
 			return textFormat.prefix + textFormat.suffix, nil
 		default:
-			return cell.Value, errors.New("invalid or unsupported format, unsupported string format")
+			return cellValue, errors.New("invalid or unsupported format, unsupported string format")
 		}
 	case CellTypeDate:
 		// These are dates that are stored in date format instead of being stored as numbers with a format to turn them

--- a/lib.go
+++ b/lib.go
@@ -464,7 +464,7 @@ func fillCellData(rawCell xlsxC, refTable *RefTable, sharedFormulas map[int]shar
 			if err != nil {
 				panic(err)
 			}
-			cell.Value = refTable.ResolveSharedString(ref)
+			cell.Value, cell.RichText = refTable.ResolveSharedString(ref)
 		}
 	case "inlineStr":
 		cell.cellType = CellTypeInline
@@ -496,13 +496,12 @@ func fillCellData(rawCell xlsxC, refTable *RefTable, sharedFormulas map[int]shar
 // fillCellDataFromInlineString attempts to get inline string data and put it into a Cell.
 func fillCellDataFromInlineString(rawcell xlsxC, cell *Cell) {
 	cell.Value = ""
+	cell.RichText = nil
 	if rawcell.Is != nil {
-		if rawcell.Is.T != "" {
-			cell.Value = strings.Trim(rawcell.Is.T, " \t\n\r")
+		if rawcell.Is.T != nil {
+			cell.Value = strings.Trim(rawcell.Is.T.getText(), " \t\n\r")
 		} else {
-			for _, r := range rawcell.Is.R {
-				cell.Value += r.T
-			}
+			cell.RichText = xmlToRichText(rawcell.Is.R)
 		}
 	}
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -81,12 +81,23 @@ func TestMemoryCellStore(t *testing.T) {
 			Operator:         "operator",
 		}
 
+		rt := []RichTextRun{
+			RichTextRun{
+				Font: &RichTextFont{Bold: true},
+				Text: "bold",
+			},
+			RichTextRun{
+				Text: "normal",
+			},
+		}
+
 		file := NewFile()
 		sheet, _ := file.AddSheet("Test")
 		row := sheet.AddRow()
 		cell := row.AddCell()
 
 		cell.Value = "value"
+		cell.RichText = rt
 		cell.formula = "formula"
 		cell.style = s
 		cell.NumFmt = "numFmt"
@@ -119,6 +130,7 @@ func TestMemoryCellStore(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		c.Assert(cell.Value, qt.Equals, cell2.Value)
+		c.Assert(cell.RichText, qt.DeepEquals, cell2.RichText)
 		c.Assert(cell.formula, qt.Equals, cell2.formula)
 		c.Assert(cell.NumFmt, qt.Equals, cell2.NumFmt)
 		c.Assert(cell.date1904, qt.Equals, cell2.date1904)

--- a/reftable.go
+++ b/reftable.go
@@ -1,19 +1,27 @@
 package xlsx
 
+type plainTextOrRichText struct {
+	plainText  string
+	isRichText bool
+	richText   []RichTextRun
+}
+
 type RefTable struct {
-	indexedStrings []string
+	indexedStrings []plainTextOrRichText
 	knownStrings   map[string]int
+	knownRichTexts map[string][]int
 	isWrite        bool
 }
 
-// NewSharedStringRefTable() creates a new, empty RefTable.
+// NewSharedStringRefTable creates a new, empty RefTable.
 func NewSharedStringRefTable() *RefTable {
 	rt := RefTable{}
 	rt.knownStrings = make(map[string]int)
+	rt.knownRichTexts = make(map[string][]int)
 	return &rt
 }
 
-// MakeSharedStringRefTable() takes an xlsxSST struct and converts
+// MakeSharedStringRefTable takes an xlsxSST struct and converts
 // it's contents to an slice of strings used to refer to string values
 // by numeric index - this is the model used within XLSX worksheet (a
 // numeric reference is stored to a shared cell value).
@@ -22,19 +30,16 @@ func MakeSharedStringRefTable(source *xlsxSST) *RefTable {
 	reftable.isWrite = false
 	for _, si := range source.SI {
 		if len(si.R) > 0 {
-			newString := ""
-			for j := 0; j < len(si.R); j++ {
-				newString = newString + si.R[j].T
-			}
-			reftable.AddString(newString)
+			richText := xmlToRichText(si.R)
+			reftable.AddRichText(richText)
 		} else {
-			reftable.AddString(si.T)
+			reftable.AddString(si.T.getText())
 		}
 	}
 	return reftable
 }
 
-// makeXlsxSST() takes a RefTable and returns and
+// makeXlsxSST takes a RefTable and returns and
 // equivalent xlsxSST representation.
 func (rt *RefTable) makeXLSXSST() xlsxSST {
 	sst := xlsxSST{}
@@ -42,18 +47,28 @@ func (rt *RefTable) makeXLSXSST() xlsxSST {
 	sst.UniqueCount = sst.Count
 	for _, ref := range rt.indexedStrings {
 		si := xlsxSI{}
-		si.T = ref
+		if ref.isRichText {
+			si.R = richTextToXml(ref.richText)
+		} else {
+			si.T = &xlsxT{Text: ref.plainText}
+		}
 		sst.SI = append(sst.SI, si)
 	}
 	return sst
 }
 
-// Resolvesharedstring() looks up a string value by numeric index from
-// a provided reference table (just a slice of strings in the correct
-// order).  This function only exists to provide clarity of purpose
-// via it's name.
-func (rt *RefTable) ResolveSharedString(index int) string {
-	return rt.indexedStrings[index]
+// ResolveSharedString looks up a string value or the rich text by numeric index from
+// a provided reference table (just a slice of strings in the correct order).
+// If the rich text was found, non-empty slice will be returned in richText.
+// This function only exists to provide clarity of purpose via it's name.
+func (rt *RefTable) ResolveSharedString(index int) (plainText string, richText []RichTextRun) {
+	ptrt := rt.indexedStrings[index]
+	if ptrt.isRichText {
+		richText = ptrt.richText
+	} else {
+		plainText = ptrt.plainText
+	}
+	return
 }
 
 // AddString adds a string to the reference table and return it's
@@ -66,10 +81,47 @@ func (rt *RefTable) AddString(str string) int {
 			return index
 		}
 	}
-	rt.indexedStrings = append(rt.indexedStrings, str)
+	ptrt := plainTextOrRichText{plainText: str, isRichText: false}
+	rt.indexedStrings = append(rt.indexedStrings, ptrt)
 	index := len(rt.indexedStrings) - 1
 	rt.knownStrings[str] = index
 	return index
+}
+
+// AddRichText adds a set of rich text to the reference table and return it's
+// numeric index.  If a set of rich text already exists then it simply returns
+// the existing index.
+func (rt *RefTable) AddRichText(r []RichTextRun) int {
+	plain := richTextToPlainText(r)
+	if rt.isWrite {
+		indices, ok := rt.knownRichTexts[plain]
+		if ok {
+			for _, index := range indices {
+				if areRichTextsEqual(rt.indexedStrings[index].richText, r) {
+					return index
+				}
+			}
+		}
+	}
+	ptrt := plainTextOrRichText{isRichText: true}
+	ptrt.richText = append(ptrt.richText, r...)
+	rt.indexedStrings = append(rt.indexedStrings, ptrt)
+	index := len(rt.indexedStrings) - 1
+	rt.knownRichTexts[plain] = append(rt.knownRichTexts[plain], index)
+	return index
+}
+
+func areRichTextsEqual(r1 []RichTextRun, r2 []RichTextRun) bool {
+	if len(r1) != len(r2) {
+		return false
+	}
+	for i, rt1 := range r1 {
+		rt2 := r2[i]
+		if !rt1.Equals(&rt2) {
+			return false
+		}
+	}
+	return true
 }
 
 func (rt *RefTable) Length() int {

--- a/richtext.go
+++ b/richtext.go
@@ -1,0 +1,207 @@
+package xlsx
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type RichTextFontFamily int
+type RichTextCharset int
+type RichTextVertAlign string
+type RichTextUnderline string
+
+const (
+	// RichTextFontFamilyUnspecified indicates that the font family was not specified
+	RichTextFontFamilyUnspecified   RichTextFontFamily = -1
+	RichTextFontFamilyNotApplicable RichTextFontFamily = 0
+	RichTextFontFamilyRoman         RichTextFontFamily = 1
+	RichTextFontFamilySwiss         RichTextFontFamily = 2
+	RichTextFontFamilyModern        RichTextFontFamily = 3
+	RichTextFontFamilyScript        RichTextFontFamily = 4
+	RichTextFontFamilyDecorative    RichTextFontFamily = 5
+
+	// RichTextCharsetUnspecified indicates that the font charset was not specified
+	RichTextCharsetUnspecified RichTextCharset = -1
+	RichTextCharsetANSI        RichTextCharset = 0
+	RichTextCharsetDefault     RichTextCharset = 1
+	RichTextCharsetSymbol      RichTextCharset = 2
+	RichTextCharsetMac         RichTextCharset = 77
+	RichTextCharsetShiftJIS    RichTextCharset = 128
+	RichTextCharsetHangul      RichTextCharset = 129
+	RichTextCharsetJohab       RichTextCharset = 130
+	RichTextCharsetGB2312      RichTextCharset = 134
+	RichTextCharsetBIG5        RichTextCharset = 136
+	RichTextCharsetGreek       RichTextCharset = 161
+	RichTextCharsetTurkish     RichTextCharset = 162
+	RichTextCharsetVietnamese  RichTextCharset = 163
+	RichTextCharsetHebrew      RichTextCharset = 177
+	RichTextCharsetArabic      RichTextCharset = 178
+	RichTextCharsetBaltic      RichTextCharset = 186
+	RichTextCharsetRussian     RichTextCharset = 204
+	RichTextCharsetThai        RichTextCharset = 222
+	RichTextCharsetEastEurope  RichTextCharset = 238
+	RichTextCharsetOEM         RichTextCharset = 255
+
+	RichTextVertAlignSuperscript RichTextVertAlign = "superscript"
+	RichTextVertAlignSubscript   RichTextVertAlign = "subscript"
+
+	RichTextUnderlineSingle RichTextUnderline = "single"
+	RichTextUnderlineDouble RichTextUnderline = "double"
+
+	// These underline styles doesn't work on the RichTextRun,
+	// and should be set as a part of cell style.
+	// "singleAccounting"
+	// "doubleAccounting"
+)
+
+// RichTextColor is the color of the RichTextRun.
+type RichTextColor struct {
+	coreColor xlsxColor
+}
+
+// NewRichTextColorFromARGB creates a new RichTextColor from ARGB component values.
+// Each component must have a value in range of 0 to 255.
+func NewRichTextColorFromARGB(alpha, red, green, blue int) *RichTextColor {
+	argb := fmt.Sprintf("%02X%02X%02X%02X", alpha, red, green, blue)
+	return &RichTextColor{coreColor: xlsxColor{RGB: argb}}
+}
+
+// NewRichTextColorFromThemeColor creates a new RichTextColor from the theme color.
+// The argument `themeColor` is a zero-based index of the theme color.
+func NewRichTextColorFromThemeColor(themeColor int) *RichTextColor {
+	return &RichTextColor{coreColor: xlsxColor{Theme: &themeColor}}
+}
+
+// RichTextFont is the font spec of the RichTextRun.
+type RichTextFont struct {
+	// Name is the font name. If Name is empty, Size, Family and Charset will be ignored.
+	Name string
+	// Size is the font size.
+	Size float64
+	// Family is a value of the font family. Use one of the RichTextFontFamily constants.
+	Family RichTextFontFamily
+	// Charset is a value of the charset of the font. Use one of the RichTextCharset constants.
+	Charset RichTextCharset
+	// Color is the text color.
+	Color *RichTextColor
+	// Bold specifies the bold face font style.
+	Bold bool
+	// Italic specifies the italic font style.
+	Italic bool
+	// Strike specifies a strikethrough line.
+	Strike bool
+	// VertAlign specifies the vertical position of the text. Use one of the RichTextVertAlign constants, or empty.
+	VertAlign RichTextVertAlign
+	// Underline specifies the underline style. Use one of the RichTextUnderline constants, or empty.
+	Underline RichTextUnderline
+}
+
+// RichTextRun is a run of the decorated text.
+type RichTextRun struct {
+	Font *RichTextFont
+	Text string
+}
+
+func (rt *RichTextRun) Equals(other *RichTextRun) bool {
+	return reflect.DeepEqual(rt, other)
+}
+
+func richTextToXml(r []RichTextRun) []xlsxR {
+	var xrs []xlsxR
+	for _, rt := range r {
+		xr := xlsxR{}
+		xr.T = xlsxT{Text: rt.Text}
+		if rt.Font != nil {
+			rpr := xlsxRunProperties{}
+			if len(rt.Font.Name) > 0 {
+				rpr.RFont = &xlsxVal{Val: rt.Font.Name}
+			}
+			if rt.Font.Size > 0.0 {
+				rpr.Sz = &xlsxFloatVal{Val: rt.Font.Size}
+			}
+			if rt.Font.Family != RichTextFontFamilyUnspecified {
+				rpr.Family = &xlsxIntVal{Val: int(rt.Font.Family)}
+			}
+			if rt.Font.Charset != RichTextCharsetUnspecified {
+				rpr.Charset = &xlsxIntVal{Val: int(rt.Font.Charset)}
+			}
+			if rt.Font.Color != nil {
+				xcolor := rt.Font.Color.coreColor
+				rpr.Color = &xcolor
+			}
+			if rt.Font.Bold {
+				rpr.B.Val = true
+			}
+			if rt.Font.Italic {
+				rpr.I.Val = true
+			}
+			if rt.Font.Strike {
+				rpr.Strike.Val = true
+			}
+			if len(rt.Font.VertAlign) > 0 {
+				rpr.VertAlign = &xlsxVal{Val: string(rt.Font.VertAlign)}
+			}
+			if len(rt.Font.Underline) > 0 {
+				rpr.U = &xlsxVal{Val: string(rt.Font.Underline)}
+			}
+			xr.RPr = &rpr
+		}
+		xrs = append(xrs, xr)
+	}
+	return xrs
+}
+
+func xmlToRichText(r []xlsxR) []RichTextRun {
+	richiText := []RichTextRun(nil)
+	for _, rr := range r {
+		rtr := RichTextRun{Text: rr.T.Text}
+		rpr := rr.RPr
+		if rpr != nil {
+			rtr.Font = &RichTextFont{}
+			if rpr.RFont != nil {
+				rtr.Font.Name = rpr.RFont.Val
+			}
+			if rpr.Sz != nil {
+				rtr.Font.Size = rpr.Sz.Val
+			}
+			if rpr.Family != nil {
+				rtr.Font.Family = RichTextFontFamily(rpr.Family.Val)
+			} else {
+				rtr.Font.Family = RichTextFontFamilyUnspecified
+			}
+			if rpr.Charset != nil {
+				rtr.Font.Charset = RichTextCharset(rpr.Charset.Val)
+			} else {
+				rtr.Font.Charset = RichTextCharsetUnspecified
+			}
+			if rpr.Color != nil {
+				rtr.Font.Color = &RichTextColor{coreColor: *rpr.Color}
+			}
+			if rpr.B.Val {
+				rtr.Font.Bold = true
+			}
+			if rpr.I.Val {
+				rtr.Font.Italic = true
+			}
+			if rpr.Strike.Val {
+				rtr.Font.Strike = true
+			}
+			if rpr.VertAlign != nil {
+				rtr.Font.VertAlign = RichTextVertAlign(rpr.VertAlign.Val)
+			}
+			if rpr.U != nil {
+				rtr.Font.Underline = RichTextUnderline(rpr.U.Val)
+			}
+		}
+		richiText = append(richiText, rtr)
+	}
+	return richiText
+}
+
+func richTextToPlainText(richText []RichTextRun) string {
+	var s string
+	for _, r := range richText {
+		s += r.Text
+	}
+	return s
+}

--- a/richtext_test.go
+++ b/richtext_test.go
@@ -1,0 +1,388 @@
+package xlsx
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type RichTextSuite struct{}
+
+var _ = Suite(&RichTextSuite{})
+
+func (s *RichTextSuite) TestNewRichTextColorFromARGB(c *C) {
+	rtColor := NewRichTextColorFromARGB(127, 128, 129, 130)
+	c.Assert(rtColor.coreColor.RGB, Equals, "7F808182")
+}
+
+func (s *RichTextSuite) TestNewRichTextColorFromThemeColor(c *C) {
+	rtColor := NewRichTextColorFromThemeColor(123)
+	c.Assert(*rtColor.coreColor.Theme, Equals, 123)
+}
+
+func (s *RichTextSuite) TestRichTextRunEquals(c *C) {
+	r1color := 1
+	r1 := &RichTextRun{
+		Font: &RichTextFont{
+			Family:  RichTextFontFamilyUnspecified,
+			Charset: RichTextCharsetUnspecified,
+			Color:   &RichTextColor{coreColor: xlsxColor{Theme: &r1color}},
+			Bold:    true,
+			Italic:  true,
+		},
+		Text: "X",
+	}
+
+	r2color := r1color
+	r2 := &RichTextRun{ // same with r1
+		Font: &RichTextFont{
+			Family:  RichTextFontFamilyUnspecified,
+			Charset: RichTextCharsetUnspecified,
+			Color:   &RichTextColor{coreColor: xlsxColor{Theme: &r2color}},
+			Bold:    true,
+			Italic:  true,
+		},
+		Text: "X",
+	}
+
+	r3color := r1color
+	r3 := &RichTextRun{ // different font setting from r1
+		Font: &RichTextFont{
+			Family:  RichTextFontFamilyUnspecified,
+			Charset: RichTextCharsetUnspecified,
+			Color:   &RichTextColor{coreColor: xlsxColor{Theme: &r3color}},
+			Bold:    true,
+			Italic:  false,
+		},
+		Text: "X",
+	}
+
+	r4color := 2
+	r4 := &RichTextRun{ // different color setting from r1
+		Font: &RichTextFont{
+			Family:  RichTextFontFamilyUnspecified,
+			Charset: RichTextCharsetUnspecified,
+			Color:   &RichTextColor{coreColor: xlsxColor{Theme: &r4color}},
+			Bold:    true,
+			Italic:  true,
+		},
+		Text: "X",
+	}
+
+	r5 := &RichTextRun{ // no font setting
+		Text: "X",
+	}
+
+	r6color := r1color
+	r6 := &RichTextRun{ // different text from r1
+		Font: &RichTextFont{
+			Family:  RichTextFontFamilyUnspecified,
+			Charset: RichTextCharsetUnspecified,
+			Color:   &RichTextColor{coreColor: xlsxColor{Theme: &r6color}},
+			Bold:    true,
+			Italic:  true,
+		},
+		Text: "Y",
+	}
+
+	var r7 *RichTextRun = nil
+
+	c.Assert(r1.Equals(r2), Equals, true)
+	c.Assert(r1.Equals(r3), Equals, false)
+	c.Assert(r1.Equals(r4), Equals, false)
+	c.Assert(r1.Equals(r5), Equals, false)
+	c.Assert(r1.Equals(r6), Equals, false)
+	c.Assert(r1.Equals(r7), Equals, false)
+
+	c.Assert(r2.Equals(r1), Equals, true)
+	c.Assert(r3.Equals(r1), Equals, false)
+	c.Assert(r4.Equals(r1), Equals, false)
+	c.Assert(r5.Equals(r1), Equals, false)
+	c.Assert(r6.Equals(r1), Equals, false)
+	c.Assert(r7.Equals(r1), Equals, false)
+
+	c.Assert(r7.Equals(nil), Equals, true)
+}
+
+func (s *RichTextSuite) TestRichTextToXml(c *C) {
+	rtr := []RichTextRun{
+		RichTextRun{
+			Font: &RichTextFont{
+				Name:      "Font",
+				Size:      12.345,
+				Family:    RichTextFontFamilyScript,
+				Charset:   RichTextCharsetHebrew,
+				Color:     &RichTextColor{coreColor: xlsxColor{RGB: "DEADBEEF"}},
+				Bold:      true,
+				Italic:    false,
+				Strike:    false,
+				VertAlign: RichTextVertAlignSuperscript,
+				Underline: RichTextUnderlineSingle,
+			},
+			Text: "Bold",
+		},
+		RichTextRun{
+			Font: &RichTextFont{
+				Family:  RichTextFontFamilyUnspecified,
+				Charset: RichTextCharsetUnspecified,
+				Italic:  true,
+			},
+			Text: "Italic",
+		},
+		RichTextRun{
+			Font: &RichTextFont{
+				Family:  RichTextFontFamilyUnspecified,
+				Charset: RichTextCharsetUnspecified,
+				Strike:  true,
+			},
+			Text: "Strike",
+		},
+		RichTextRun{
+			Font: &RichTextFont{},
+			Text: "Empty",
+		},
+		RichTextRun{
+			Text: "No Font",
+		},
+	}
+
+	xmlr := richTextToXml(rtr)
+	c.Assert(xmlr, HasLen, 5)
+
+	r := xmlr[0]
+	c.Assert(r.RPr.RFont.Val, Equals, "Font")
+	c.Assert(r.RPr.Charset.Val, Equals, int(RichTextCharsetHebrew))
+	c.Assert(r.RPr.Family.Val, Equals, int(RichTextFontFamilyScript))
+	c.Assert(r.RPr.B.Val, Equals, true)
+	c.Assert(r.RPr.I.Val, Equals, false)
+	c.Assert(r.RPr.Strike.Val, Equals, false)
+	c.Assert(r.RPr.Outline.Val, Equals, false)
+	c.Assert(r.RPr.Shadow.Val, Equals, false)
+	c.Assert(r.RPr.Condense.Val, Equals, false)
+	c.Assert(r.RPr.Extend.Val, Equals, false)
+	c.Assert(r.RPr.Color.RGB, Equals, "DEADBEEF")
+	c.Assert(r.RPr.Sz.Val, Equals, 12.345)
+	c.Assert(r.RPr.U.Val, Equals, string(RichTextUnderlineSingle))
+	c.Assert(r.RPr.VertAlign.Val, Equals, string(RichTextVertAlignSuperscript))
+	c.Assert(r.RPr.Scheme, IsNil)
+	c.Assert(r.T.Text, Equals, "Bold")
+
+	r = xmlr[1]
+	c.Assert(r.RPr.RFont, IsNil)
+	c.Assert(r.RPr.Charset, IsNil)
+	c.Assert(r.RPr.Family, IsNil)
+	c.Assert(r.RPr.B.Val, Equals, false)
+	c.Assert(r.RPr.I.Val, Equals, true)
+	c.Assert(r.RPr.Strike.Val, Equals, false)
+	c.Assert(r.RPr.Outline.Val, Equals, false)
+	c.Assert(r.RPr.Shadow.Val, Equals, false)
+	c.Assert(r.RPr.Condense.Val, Equals, false)
+	c.Assert(r.RPr.Extend.Val, Equals, false)
+	c.Assert(r.RPr.Color, IsNil)
+	c.Assert(r.RPr.Sz, IsNil)
+	c.Assert(r.RPr.U, IsNil)
+	c.Assert(r.RPr.VertAlign, IsNil)
+	c.Assert(r.RPr.Scheme, IsNil)
+	c.Assert(r.T.Text, Equals, "Italic")
+
+	r = xmlr[2]
+	c.Assert(r.RPr.RFont, IsNil)
+	c.Assert(r.RPr.Charset, IsNil)
+	c.Assert(r.RPr.Family, IsNil)
+	c.Assert(r.RPr.B.Val, Equals, false)
+	c.Assert(r.RPr.I.Val, Equals, false)
+	c.Assert(r.RPr.Strike.Val, Equals, true)
+	c.Assert(r.RPr.Outline.Val, Equals, false)
+	c.Assert(r.RPr.Shadow.Val, Equals, false)
+	c.Assert(r.RPr.Condense.Val, Equals, false)
+	c.Assert(r.RPr.Extend.Val, Equals, false)
+	c.Assert(r.RPr.Color, IsNil)
+	c.Assert(r.RPr.Sz, IsNil)
+	c.Assert(r.RPr.U, IsNil)
+	c.Assert(r.RPr.VertAlign, IsNil)
+	c.Assert(r.RPr.Scheme, IsNil)
+	c.Assert(r.T.Text, Equals, "Strike")
+
+	r = xmlr[3]
+	c.Assert(r.RPr.RFont, IsNil)
+	c.Assert(r.RPr.Charset.Val, Equals, int(RichTextCharsetANSI))
+	c.Assert(r.RPr.Family.Val, Equals, int(RichTextFontFamilyNotApplicable))
+	c.Assert(r.RPr.B.Val, Equals, false)
+	c.Assert(r.RPr.I.Val, Equals, false)
+	c.Assert(r.RPr.Strike.Val, Equals, false)
+	c.Assert(r.RPr.Outline.Val, Equals, false)
+	c.Assert(r.RPr.Shadow.Val, Equals, false)
+	c.Assert(r.RPr.Condense.Val, Equals, false)
+	c.Assert(r.RPr.Extend.Val, Equals, false)
+	c.Assert(r.RPr.Color, IsNil)
+	c.Assert(r.RPr.Sz, IsNil)
+	c.Assert(r.RPr.U, IsNil)
+	c.Assert(r.RPr.VertAlign, IsNil)
+	c.Assert(r.RPr.Scheme, IsNil)
+	c.Assert(r.T.Text, Equals, "Empty")
+
+	r = xmlr[4]
+	c.Assert(r.RPr, IsNil)
+	c.Assert(r.T.Text, Equals, "No Font")
+}
+
+func (s *RichTextSuite) TestXmlToRichText(c *C) {
+	xmlr := []xlsxR{
+		xlsxR{
+			RPr: &xlsxRunProperties{
+				RFont:     &xlsxVal{Val: "Font"},
+				Charset:   &xlsxIntVal{Val: int(RichTextCharsetGreek)},
+				Family:    &xlsxIntVal{Val: int(RichTextFontFamilySwiss)},
+				B:         xlsxBoolProp{Val: true},
+				I:         xlsxBoolProp{Val: false},
+				Strike:    xlsxBoolProp{Val: false},
+				Outline:   xlsxBoolProp{Val: false},
+				Shadow:    xlsxBoolProp{Val: false},
+				Condense:  xlsxBoolProp{Val: false},
+				Extend:    xlsxBoolProp{Val: false},
+				Color:     &xlsxColor{RGB: "DEADBEEF"},
+				Sz:        &xlsxFloatVal{Val: 12.345},
+				U:         &xlsxVal{Val: string(RichTextUnderlineDouble)},
+				VertAlign: &xlsxVal{Val: string(RichTextVertAlignSuperscript)},
+				Scheme:    nil,
+			},
+			T: xlsxT{Text: "Bold"},
+		},
+		xlsxR{
+			RPr: &xlsxRunProperties{
+				RFont:     nil,
+				Charset:   nil,
+				Family:    nil,
+				B:         xlsxBoolProp{Val: false},
+				I:         xlsxBoolProp{Val: true},
+				Strike:    xlsxBoolProp{Val: false},
+				Outline:   xlsxBoolProp{Val: false},
+				Shadow:    xlsxBoolProp{Val: false},
+				Condense:  xlsxBoolProp{Val: false},
+				Extend:    xlsxBoolProp{Val: false},
+				Color:     nil,
+				Sz:        nil,
+				U:         nil,
+				VertAlign: nil,
+				Scheme:    nil,
+			},
+			T: xlsxT{Text: "Italic"},
+		},
+		xlsxR{
+			RPr: &xlsxRunProperties{
+				RFont:     nil,
+				Charset:   nil,
+				Family:    nil,
+				B:         xlsxBoolProp{Val: false},
+				I:         xlsxBoolProp{Val: false},
+				Strike:    xlsxBoolProp{Val: true},
+				Outline:   xlsxBoolProp{Val: false},
+				Shadow:    xlsxBoolProp{Val: false},
+				Condense:  xlsxBoolProp{Val: false},
+				Extend:    xlsxBoolProp{Val: false},
+				Color:     nil,
+				Sz:        nil,
+				U:         nil,
+				VertAlign: nil,
+				Scheme:    nil,
+			},
+			T: xlsxT{Text: "Strike"},
+		},
+		xlsxR{
+			RPr: &xlsxRunProperties{},
+			T:   xlsxT{Text: "Empty"},
+		},
+		xlsxR{
+			RPr: nil,
+			T:   xlsxT{Text: "No Font"},
+		},
+	}
+
+	rtr := xmlToRichText(xmlr)
+	c.Assert(rtr, HasLen, 5)
+
+	r := rtr[0]
+	c.Assert(r.Font.Name, Equals, "Font")
+	c.Assert(r.Font.Size, Equals, 12.345)
+	c.Assert(r.Font.Family, Equals, RichTextFontFamilySwiss)
+	c.Assert(r.Font.Charset, Equals, RichTextCharsetGreek)
+	c.Assert(r.Font.Color.coreColor.RGB, Equals, "DEADBEEF")
+	c.Assert(r.Font.Bold, Equals, true)
+	c.Assert(r.Font.Italic, Equals, false)
+	c.Assert(r.Font.Strike, Equals, false)
+	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlignSuperscript)
+	c.Assert(r.Font.Underline, Equals, RichTextUnderlineDouble)
+	c.Assert(r.Text, Equals, "Bold")
+
+	r = rtr[1]
+	c.Assert(r.Font.Name, Equals, "")
+	c.Assert(r.Font.Size, Equals, 0.0)
+	c.Assert(r.Font.Family, Equals, RichTextFontFamilyUnspecified)
+	c.Assert(r.Font.Charset, Equals, RichTextCharsetUnspecified)
+	c.Assert(r.Font.Color, IsNil)
+	c.Assert(r.Font.Bold, Equals, false)
+	c.Assert(r.Font.Italic, Equals, true)
+	c.Assert(r.Font.Strike, Equals, false)
+	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlign(""))
+	c.Assert(r.Font.Underline, Equals, RichTextUnderline(""))
+	c.Assert(r.Text, Equals, "Italic")
+
+	r = rtr[2]
+	c.Assert(r.Font.Name, Equals, "")
+	c.Assert(r.Font.Size, Equals, 0.0)
+	c.Assert(r.Font.Family, Equals, RichTextFontFamilyUnspecified)
+	c.Assert(r.Font.Charset, Equals, RichTextCharsetUnspecified)
+	c.Assert(r.Font.Color, IsNil)
+	c.Assert(r.Font.Bold, Equals, false)
+	c.Assert(r.Font.Italic, Equals, false)
+	c.Assert(r.Font.Strike, Equals, true)
+	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlign(""))
+	c.Assert(r.Font.Underline, Equals, RichTextUnderline(""))
+	c.Assert(r.Text, Equals, "Strike")
+
+	r = rtr[3]
+	c.Assert(r.Font.Name, Equals, "")
+	c.Assert(r.Font.Size, Equals, 0.0)
+	c.Assert(r.Font.Family, Equals, RichTextFontFamilyUnspecified)
+	c.Assert(r.Font.Charset, Equals, RichTextCharsetUnspecified)
+	c.Assert(r.Font.Color, IsNil)
+	c.Assert(r.Font.Bold, Equals, false)
+	c.Assert(r.Font.Italic, Equals, false)
+	c.Assert(r.Font.Strike, Equals, false)
+	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlign(""))
+	c.Assert(r.Font.Underline, Equals, RichTextUnderline(""))
+	c.Assert(r.Text, Equals, "Empty")
+
+	r = rtr[4]
+	c.Assert(r.Font, IsNil)
+	c.Assert(r.Text, Equals, "No Font")
+}
+
+func (s *RichTextSuite) TestRichTextToPlainText(c *C) {
+	rt := []RichTextRun{
+		RichTextRun{
+			Font: &RichTextFont{
+				Bold: true,
+			},
+			Text: "Bold",
+		},
+		RichTextRun{
+			Font: &RichTextFont{
+				Italic: true,
+			},
+			Text: "Italic",
+		},
+		RichTextRun{
+			Font: &RichTextFont{
+				Strike: true,
+			},
+			Text: "Strike",
+		},
+	}
+	plainText := richTextToPlainText(rt)
+	c.Assert(plainText, Equals, "BoldItalicStrike")
+}
+
+func (s *RichTextSuite) TestRichTextToPlainTextEmpty(c *C) {
+	rt := []RichTextRun{}
+	plainText := richTextToPlainText(rt)
+	c.Assert(plainText, Equals, "")
+}

--- a/sheet.go
+++ b/sheet.go
@@ -546,6 +546,8 @@ func (s *Sheet) makeRows(worksheet *xlsxWorksheet, styles *xlsxStyleSheet, refTa
 			case CellTypeString:
 				if len(cell.Value) > 0 {
 					xC.V = strconv.Itoa(refTable.AddString(cell.Value))
+				} else if len(cell.RichText) > 0 {
+					xC.V = strconv.Itoa(refTable.AddRichText(cell.RichText))
 				}
 				xC.T = "s"
 			case CellTypeNumeric:

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -195,7 +195,8 @@ func TestSheet(t *testing.T) {
 		c.Assert(xSST.UniqueCount, qt.Equals, 1)
 		c.Assert(len(xSST.SI), qt.Equals, 1)
 		xSI := xSST.SI[0]
-		c.Assert(xSI.T, qt.Equals, "A cell!")
+		c.Assert(xSI.T.Text, qt.Equals, "A cell!")
+		c.Assert(xSI.R, qt.HasLen, 0)
 	})
 
 	// If the column width is not customised, the xslxCol.CustomWidth field is set to 0.

--- a/stream_file.go
+++ b/stream_file.go
@@ -318,12 +318,12 @@ func makeXlsxCell(cellType CellType, cellCoordinate string, cellStyleId int, cel
 	case CellTypeError:
 		return xlsxC{XMLName: xml.Name{Local: "c"}, R: cellCoordinate, S: cellStyleId, T: "e", V: cellData}, nil
 	case CellTypeInline:
-		return xlsxC{XMLName: xml.Name{Local: "c"}, R: cellCoordinate, S: cellStyleId, T: "inlineStr", Is: &xlsxSI{T: cellData}}, nil
+		return xlsxC{XMLName: xml.Name{Local: "c"}, R: cellCoordinate, S: cellStyleId, T: "inlineStr", Is: &xlsxSI{T: &xlsxT{Text: cellData}}}, nil
 	case CellTypeNumeric:
 		return xlsxC{XMLName: xml.Name{Local: "c"}, R: cellCoordinate, S: cellStyleId, T: "n", V: cellData}, nil
 	case CellTypeString:
 		// TODO Currently shared strings are types as inline strings
-		return xlsxC{XMLName: xml.Name{Local: "c"}, R: cellCoordinate, S: cellStyleId, T: "inlineStr", Is: &xlsxSI{T: cellData}}, nil
+		return xlsxC{XMLName: xml.Name{Local: "c"}, R: cellCoordinate, S: cellStyleId, T: "inlineStr", Is: &xlsxSI{T: &xlsxT{Text: cellData}}}, nil
 	// TODO currently not supported
 	// case CellTypeStringFormula:
 	// return xlsxC{}, UnsupportedCellTypeError

--- a/xmlSharedStrings.go
+++ b/xmlSharedStrings.go
@@ -2,6 +2,8 @@ package xlsx
 
 import (
 	"encoding/xml"
+	"errors"
+	"strings"
 )
 
 // xlsxSST directly maps the sst element from the namespace
@@ -19,7 +21,7 @@ type xlsxSST struct {
 // currently I have not checked this for completeness - it does as
 // much as I need.
 type xlsxSI struct {
-	T string  `xml:"t"`
+	T *xlsxT  `xml:"t"`
 	R []xlsxR `xml:"r"`
 }
 
@@ -28,5 +30,135 @@ type xlsxSI struct {
 // currently I have not checked this for completeness - it does as
 // much as I need.
 type xlsxR struct {
-	T string `xml:"t"`
+	RPr *xlsxRunProperties `xml:"rPr"`
+	T   xlsxT              `xml:"t"`
+}
+
+// xlsxRunProperties directly maps the rPr element from the namespace
+// http://schemas.openxmlformats.org/spreadsheetml/2006/main
+type xlsxRunProperties struct {
+	RFont     *xlsxVal      `xml:"rFont"`
+	Charset   *xlsxIntVal   `xml:"charset"`
+	Family    *xlsxIntVal   `xml:"family"`
+	B         xlsxBoolProp  `xml:"b"`
+	I         xlsxBoolProp  `xml:"i"`
+	Strike    xlsxBoolProp  `xml:"strike"`
+	Outline   xlsxBoolProp  `xml:"outline"`
+	Shadow    xlsxBoolProp  `xml:"shadow"`
+	Condense  xlsxBoolProp  `xml:"condense"`
+	Extend    xlsxBoolProp  `xml:"extend"`
+	Color     *xlsxColor    `xml:"color"`
+	Sz        *xlsxFloatVal `xml:"sz"`
+	U         *xlsxVal      `xml:"u"`
+	VertAlign *xlsxVal      `xml:"vertAlign"`
+	Scheme    *xlsxVal      `xml:"scheme"`
+}
+
+// xlsxBoolProp handles "CT_BooleanProperty" type which is declared in the XML Schema of Office Open XML.
+// XML attribute "val" is optional. If "val" was omitted, the property value becomes "true".
+// On the serialization, the struct which has "true" will be serialized an empty XML tag without "val" attributes,
+// and the struct which has "false" will not be serialized.
+type xlsxBoolProp struct {
+	Val bool `xml:"val,addr"`
+}
+
+// MarshalXML implements xml.Marshaler interface for xlsxBoolProp
+func (b *xlsxBoolProp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if b.Val {
+		if err := e.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := e.EncodeToken(xml.EndElement{Name: start.Name}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalXML implements xml.Unmarshaler interface for xlsxBoolProp
+func (b *xlsxBoolProp) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	boolVal := true
+	for _, attr := range start.Attr {
+		if attr.Name.Space == "" && attr.Name.Local == "val" {
+			// supports xsd:boolean
+			switch attr.Value {
+			case "true", "1":
+				boolVal = true
+			case "false", "0":
+				boolVal = false
+			default:
+				return errors.New(
+					"Cannot unmarshal into xlsxBoolProp: \"" +
+						attr.Value + "\" is not a valid boolean value")
+			}
+		}
+	}
+	b.Val = boolVal
+	return d.Skip()
+}
+
+// xlsxIntVal is like xlsxVal, except it has an int value
+type xlsxIntVal struct {
+	Val int `xml:"val,attr"`
+}
+
+// xlsxFloatVal is like xlsxVal, except it has a float value
+type xlsxFloatVal struct {
+	Val float64 `xml:"val,attr"`
+}
+
+// xlsxT represents a text. It will be serialized as a XML tag which has character data.
+// Attribute xml:space="preserve" will be added to the XML tag if needed.
+type xlsxT struct {
+	Text string `xml:",chardata"`
+}
+
+// MarshalXML implements xml.Marshaler interface for xlsxT
+func (t *xlsxT) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if needPreserve(t.Text) {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "xml:space"},
+			Value: "preserve",
+		}
+		start.Attr = append(start.Attr, attr)
+	}
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(xml.CharData(t.Text)); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(xml.EndElement{Name: start.Name}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getText is a nil-safe utility function that gets a string from xlsxT.
+// If the pointer of xlsxT was nil, returns an empty string.
+func (t *xlsxT) getText() string {
+	if t == nil {
+		return ""
+	}
+	return t.Text
+}
+
+// needPreserve determines whether xml:space="preserve" is needed.
+func needPreserve(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	// Note:
+	// xml:space="preserve" is not needed for CR and TAB
+	// because they are serialized as "&#xD;" and "&#x9;".
+	c := s[0]
+	if c <= 32 && c != 9 && c != 13 {
+		return true
+	}
+	c = s[len(s)-1]
+	if c <= 32 && c != 9 && c != 13 {
+		return true
+	}
+	return strings.ContainsRune(s, '\u000a')
 }

--- a/xmlSharedStrings_test.go
+++ b/xmlSharedStrings_test.go
@@ -17,8 +17,8 @@ func (s *SharedStringsSuite) SetUpTest(c *C) {
 	s.SharedStringsXML = bytes.NewBufferString(
 		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-             count="4"
-             uniqueCount="4">
+             count="5"
+             uniqueCount="5">
           <si>
             <t>Foo</t>
           </si>
@@ -31,6 +31,39 @@ func (s *SharedStringsSuite) SetUpTest(c *C) {
           <si>
             <t>Quuk</t>
           </si>
+          <si>
+			<r>
+				<t>Normal</t>
+			</r>
+			<r>
+				<rPr>
+				</rPr>
+				<t>Normal2</t>
+			</r>
+			<r>
+				<rPr>
+					<b val="true"/>
+					<i val="false"/>
+					<strike/>
+					<condense val="1"/>
+					<extend val="0"/>
+				</rPr>
+				<t>Bools</t>
+			</r>
+			<r>
+				<rPr>
+					<sz val="13.5"/><color theme="1"/><rFont val="FontZ"/><family val="2"/><charset val="128"/><scheme val="minor"/>
+				</rPr>
+				<t>Font Spec</t>
+			</r>
+			<r>
+				<rPr>
+					<u val="single"/>
+					<vertAlign val="superscript"/>
+				</rPr>
+				<t>Misc</t>
+			</r>
+          </si>
         </sst>`)
 }
 
@@ -40,9 +73,138 @@ func (s *SharedStringsSuite) TestUnmarshallSharedStrings(c *C) {
 	sst := new(xlsxSST)
 	err := xml.NewDecoder(s.SharedStringsXML).Decode(sst)
 	c.Assert(err, IsNil)
-	c.Assert(sst.Count, Equals, 4)
-	c.Assert(sst.UniqueCount, Equals, 4)
-	c.Assert(sst.SI, HasLen, 4)
+	c.Assert(sst.Count, Equals, 5)
+	c.Assert(sst.UniqueCount, Equals, 5)
+	c.Assert(sst.SI, HasLen, 5)
+
 	si := sst.SI[0]
-	c.Assert(si.T, Equals, "Foo")
+	c.Assert(si.T.Text, Equals, "Foo")
+	c.Assert(si.R, IsNil)
+	si = sst.SI[1]
+	c.Assert(si.T.Text, Equals, "Bar")
+	c.Assert(si.R, IsNil)
+	si = sst.SI[2]
+	c.Assert(si.T.Text, Equals, "Baz ")
+	c.Assert(si.R, IsNil)
+	si = sst.SI[3]
+	c.Assert(si.T.Text, Equals, "Quuk")
+	c.Assert(si.R, IsNil)
+	si = sst.SI[4]
+	c.Assert(si.T, IsNil)
+	c.Assert(len(si.R), Equals, 5)
+	r := si.R[0]
+	c.Assert(r.T.Text, Equals, "Normal")
+	c.Assert(r.RPr, IsNil)
+	r = si.R[1]
+	c.Assert(r.T.Text, Equals, "Normal2")
+	c.Assert(r.RPr.RFont, IsNil)
+	c.Assert(r.RPr.Sz, IsNil)
+	c.Assert(r.RPr.Color, IsNil)
+	c.Assert(r.RPr.Family, IsNil)
+	c.Assert(r.RPr.Charset, IsNil)
+	c.Assert(r.RPr.Scheme, IsNil)
+	c.Assert(r.RPr.B.Val, Equals, false)
+	c.Assert(r.RPr.I.Val, Equals, false)
+	c.Assert(r.RPr.Strike.Val, Equals, false)
+	c.Assert(r.RPr.Outline.Val, Equals, false)
+	c.Assert(r.RPr.Shadow.Val, Equals, false)
+	c.Assert(r.RPr.Condense.Val, Equals, false)
+	c.Assert(r.RPr.Extend.Val, Equals, false)
+	c.Assert(r.RPr.U, IsNil)
+	c.Assert(r.RPr.VertAlign, IsNil)
+	r = si.R[2]
+	c.Assert(r.T.Text, Equals, "Bools")
+	c.Assert(r.RPr.RFont, IsNil)
+	c.Assert(r.RPr.B.Val, Equals, true)
+	c.Assert(r.RPr.I.Val, Equals, false)
+	c.Assert(r.RPr.Strike.Val, Equals, true)
+	c.Assert(r.RPr.Condense.Val, Equals, true)
+	c.Assert(r.RPr.Extend.Val, Equals, false)
+	r = si.R[3]
+	c.Assert(r.T.Text, Equals, "Font Spec")
+	c.Assert(r.RPr.RFont.Val, Equals, "FontZ")
+	c.Assert(r.RPr.Sz.Val, Equals, 13.5)
+	c.Assert(*r.RPr.Color.Theme, Equals, 1)
+	c.Assert(r.RPr.Family.Val, Equals, 2)
+	c.Assert(r.RPr.Charset.Val, Equals, 128)
+	c.Assert(r.RPr.Scheme.Val, Equals, "minor")
+	r = si.R[4]
+	c.Assert(r.T.Text, Equals, "Misc")
+	c.Assert(r.RPr.U.Val, Equals, "single")
+	c.Assert(r.RPr.VertAlign.Val, Equals, "superscript")
+}
+
+// TestMarshalSI_T tests that xlsxT is marshaled as it is expected.
+func (s *SharedStringsSuite) TestMarshalSI_T(c *C) {
+	testMarshalSIT(c, "", "<xlsxSI><t></t></xlsxSI>")
+	testMarshalSIT(c, "a b c", "<xlsxSI><t>a b c</t></xlsxSI>")
+	testMarshalSIT(c, " abc", "<xlsxSI><t xml:space=\"preserve\"> abc</t></xlsxSI>")
+	testMarshalSIT(c, "abc ", "<xlsxSI><t xml:space=\"preserve\">abc </t></xlsxSI>")
+	testMarshalSIT(c, "\nabc", "<xlsxSI><t xml:space=\"preserve\">\nabc</t></xlsxSI>")
+	testMarshalSIT(c, "abc\n", "<xlsxSI><t xml:space=\"preserve\">abc\n</t></xlsxSI>")
+	testMarshalSIT(c, "ab\nc", "<xlsxSI><t xml:space=\"preserve\">ab\nc</t></xlsxSI>")
+}
+
+func testMarshalSIT(c *C, t string, expected string) {
+	si := xlsxSI{T: &xlsxT{Text: t}}
+	bytes, err := xml.Marshal(&si)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes), Equals, expected)
+}
+
+// TestMarshalSI_R tests that xlsxR is marshaled as it is expected.
+func (s *SharedStringsSuite) TestMarshalSI_R(c *C) {
+	testMarshalSIR(c, xlsxR{}, "<xlsxSI><r><t></t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a b c"}}, "<xlsxSI><r><t>a b c</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: " abc"}}, "<xlsxSI><r><t xml:space=\"preserve\"> abc</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "abc "}}, "<xlsxSI><r><t xml:space=\"preserve\">abc </t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "\nabc"}}, "<xlsxSI><r><t xml:space=\"preserve\">\nabc</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "abc\n"}}, "<xlsxSI><r><t xml:space=\"preserve\">abc\n</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "ab\nc"}}, "<xlsxSI><r><t xml:space=\"preserve\">ab\nc</t></r></xlsxSI>")
+
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{RFont: &xlsxVal{Val: "Times New Roman"}}},
+		"<xlsxSI><r><rPr><rFont val=\"Times New Roman\"></rFont></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Charset: &xlsxIntVal{Val: 1}}},
+		"<xlsxSI><r><rPr><charset val=\"1\"></charset></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Family: &xlsxIntVal{Val: 1}}},
+		"<xlsxSI><r><rPr><family val=\"1\"></family></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{B: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><b></b></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{I: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><i></i></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Strike: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><strike></strike></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Outline: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><outline></outline></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Shadow: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><shadow></shadow></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Condense: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><condense></condense></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Extend: xlsxBoolProp{Val: true}}},
+		"<xlsxSI><r><rPr><extend></extend></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Color: &xlsxColor{RGB: "FF123456"}}},
+		"<xlsxSI><r><rPr><color rgb=\"FF123456\"></color></rPr><t>a</t></r></xlsxSI>")
+	colorIndex := 11
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Color: &xlsxColor{Indexed: &colorIndex}}},
+		"<xlsxSI><r><rPr><color indexed=\"11\"></color></rPr><t>a</t></r></xlsxSI>")
+	colorTheme := 5
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Color: &xlsxColor{Theme: &colorTheme}}},
+		"<xlsxSI><r><rPr><color theme=\"5\"></color></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Color: &xlsxColor{Theme: &colorTheme, Tint: 0.1}}},
+		"<xlsxSI><r><rPr><color theme=\"5\" tint=\"0.1\"></color></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Sz: &xlsxFloatVal{Val: 12.5}}},
+		"<xlsxSI><r><rPr><sz val=\"12.5\"></sz></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{U: &xlsxVal{Val: "single"}}},
+		"<xlsxSI><r><rPr><u val=\"single\"></u></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{VertAlign: &xlsxVal{Val: "superscript"}}},
+		"<xlsxSI><r><rPr><vertAlign val=\"superscript\"></vertAlign></rPr><t>a</t></r></xlsxSI>")
+	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a"}, RPr: &xlsxRunProperties{Scheme: &xlsxVal{Val: "major"}}},
+		"<xlsxSI><r><rPr><scheme val=\"major\"></scheme></rPr><t>a</t></r></xlsxSI>")
+}
+
+func testMarshalSIR(c *C, r xlsxR, expected string) {
+	si := xlsxSI{R: []xlsxR{r}}
+	bytes, err := xml.Marshal(&si)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes), Equals, expected)
 }


### PR DESCRIPTION
This pull request add support of the rich text in the cell.

The points are as follows.

### Read existing XLSX file

`<r>` tags (include children tags like `<rPr>`,`<rFont>`,`<family>`...) in sharedStrings.xml are deserialized to the []RichTextRun.

They can be read from the new field Cell.RichText.

Cell.FormattedValue() returns plain text converted from the rich text.

### Write XLSX file

RefTable can handle both plain text and rich text.

In sharedStrings.xml, []RichTextRun are serialized as `<r>` tags and their children.

To retain white spaces in rich text, `<t xml:space="preserve">` is used to output text fragment which have leading/trailing white spaces.
In addition, conventional normal texts are also processed in the same manner. This may be **a breaking change**.

### Edit Cell

To add rich text into the cell, Cell.SetRichText() is used instead of Cell.SetValue().

[Sample code](https://gist.github.com/kzmi/00b94f597858e4884787e631bc03d56a)

![Result](https://user-images.githubusercontent.com/3753969/77450241-59141880-6e36-11ea-8106-05828e4bb3e9.png)


