### PR TITLE
fix for maybeAddRow func

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -264,8 +264,8 @@ func (s *Sheet) RemoveRowAtIndex(index int) error {
 // Make sure we always have as many Rows as we do cells.
 func (s *Sheet) maybeAddRow(rowCount int) {
 	if rowCount > s.MaxRow {
-		loopCnt := rowCount - s.MaxRow
-		for i := 0; i < loopCnt; i++ {
+		i := s.MaxRow
+		for ; i < rowCount; i++ {
 
 			row := &Row{Sheet: s, num: i, cells: make([]*Cell, 0)}
 			s.setCurrentRow(row)


### PR DESCRIPTION
when we add rows one by one  in current state maybeAddRow func always will push row in 0 rowNum

Example about what i mean: 
```
  file := xlsx.NewFile()
  sheet, _ := file.AddSheet(“test”)

  var row *xlsx.Row

  row, _ = sheet.Row(0)
  row.GetCell(0).SetString(“1”)
  row.GetCell(1).SetString(“1”)

  row, _ = sheet.Row(1)
  row.GetCell(0).SetString(“2”)
  row.GetCell(1).SetString(“2”)

  row, _ = sheet.Row(2)
  row.GetCell(0).SetString(“3”)
  row.GetCell(1).SetString(“3”)

  row, _ = sheet.Row(3)
  row.GetCell(0).SetString(“4”)
  row.GetCell(1).SetString(“4”)
```

