### PR TITLE
simplify ColIndexToLetters()

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -72,82 +72,20 @@ func ColLettersToIndex(letters string) int {
 	return sum
 }
 
-// Get the largestDenominator that is a multiple of a basedDenominator
-// and fits at least once into a given numerator.
-func getLargestDenominator(numerator, multiple, baseDenominator, power int) (int, int) {
-	if numerator/multiple == 0 {
-		return 1, power
-	}
-	next, nextPower := getLargestDenominator(
-		numerator, multiple*baseDenominator, baseDenominator, power+1)
-	if next > multiple {
-		return next, nextPower
-	}
-	return multiple, power
-}
-
-// Convers a list of numbers representing a column into a alphabetic
-// representation, as used in the spreadsheet.
-func formatColumnName(colId []int) string {
-	lastPart := len(colId) - 1
-
-	var result strings.Builder
-	for n, part := range colId {
-		if n == lastPart {
-			// The least significant number is in the
-			// range 0-25, all other numbers are 1-26,
-			// hence we use a differente offset for the
-			// last part.
-			result.WriteRune(rune(part + 65))
-		} else {
-			// Don't output leading 0s, as there is no
-			// representation of 0 in this format.
-			if part > 0 {
-				result.WriteRune(rune(part + 64))
-			}
-		}
-	}
-	return result.String()
-}
-
-func smooshBase26Slice(b26 []int) []int {
-	// Smoosh values together, eliminating 0s from all but the
-	// least significant part.
-	lastButOnePart := len(b26) - 2
-	for i := lastButOnePart; i > 0; i-- {
-		part := b26[i]
-		if part == 0 {
-			greaterPart := b26[i-1]
-			if greaterPart > 0 {
-				b26[i-1] = greaterPart - 1
-				b26[i] = 26
-			}
-		}
-	}
-	return b26
-}
-
-func intToBase26(x int) (parts []int) {
-	// Excel column codes are pure evil - in essence they're just
-	// base26, but they don't represent the number 0.
-	b26Denominator, _ := getLargestDenominator(x, 1, 26, 0)
-
-	// This loop terminates because integer division of 1 / 26
-	// returns 0.
-	for d := b26Denominator; d > 0; d = d / 26 {
-		value := x / d
-		remainder := x % d
-		parts = append(parts, value)
-		x = remainder
-	}
-	return parts
-}
-
 // ColIndexToLetters is used to convert a zero based, numeric column
 // indentifier into a character code.
-func ColIndexToLetters(colRef int) string {
-	parts := intToBase26(colRef)
-	return formatColumnName(smooshBase26Slice(parts))
+func ColIndexToLetters(n int) string {
+	// taken from https://github.com/psmithuk/xlsx/blob/master/xlsx.go
+	var s string
+	n += 1
+
+	for n > 0 {
+		n -= 1
+		s = string('A'+(n%26)) + s
+		n /= 26
+	}
+
+	return s
 }
 
 // RowIndexToString is used to convert a zero based, numeric row

--- a/lib_test.go
+++ b/lib_test.go
@@ -129,56 +129,6 @@ func TestLib(t *testing.T) {
 		c.Assert(output.String(), qt.Equals, expectedXML)
 	})
 
-	// Excel column codes are a special form of base26 that doesn't allow
-	// zeros, except in the least significant part of the code.  Test we
-	// can smoosh the numbers in a normal base26 representation (presented
-	// as a slice of integers) down to this form.
-	c.Run("SmooshBase26Slice", func(c *qt.C) {
-		input := []int{20, 0, 1}
-		expected := []int{19, 26, 1}
-		c.Assert(smooshBase26Slice(input), qt.DeepEquals, expected)
-	})
-
-	// formatColumnName converts slices of base26 integers to alphabetical
-	// column names.  Note that the least signifcant character has a
-	// different numeric offset (Yuck!)
-	c.Run("FormatColumnName", func(c *qt.C) {
-		c.Assert(formatColumnName([]int{0}), qt.Equals, "A")
-		c.Assert(formatColumnName([]int{25}), qt.Equals, "Z")
-		c.Assert(formatColumnName([]int{1, 25}), qt.Equals, "AZ")
-		c.Assert(formatColumnName([]int{26, 25}), qt.Equals, "ZZ")
-		c.Assert(formatColumnName([]int{26, 26, 25}), qt.Equals, "ZZZ")
-	})
-
-	// getLargestDenominator returns the largest power of a provided value
-	// that can fit within a given value.
-	c.Run("GetLargestDenominator", func(c *qt.C) {
-		d, p := getLargestDenominator(0, 1, 2, 0)
-		c.Assert(d, qt.Equals, 1)
-		c.Assert(p, qt.Equals, 0)
-		d, p = getLargestDenominator(1, 1, 2, 0)
-		c.Assert(d, qt.Equals, 1)
-		c.Assert(p, qt.Equals, 0)
-		d, p = getLargestDenominator(2, 1, 2, 0)
-		c.Assert(d, qt.Equals, 2)
-		c.Assert(p, qt.Equals, 1)
-		d, p = getLargestDenominator(4, 1, 2, 0)
-		c.Assert(d, qt.Equals, 4)
-		c.Assert(p, qt.Equals, 2)
-		d, p = getLargestDenominator(8, 1, 2, 0)
-		c.Assert(d, qt.Equals, 8)
-		c.Assert(p, qt.Equals, 3)
-		d, p = getLargestDenominator(9, 1, 2, 0)
-		c.Assert(d, qt.Equals, 8)
-		c.Assert(p, qt.Equals, 3)
-		d, p = getLargestDenominator(15, 1, 2, 0)
-		c.Assert(d, qt.Equals, 8)
-		c.Assert(p, qt.Equals, 3)
-		d, p = getLargestDenominator(16, 1, 2, 0)
-		c.Assert(d, qt.Equals, 16)
-		c.Assert(p, qt.Equals, 4)
-	})
-
 	c.Run("LettersToNumeric", func(c *qt.C) {
 		cases := map[string]int{"A": 0, "G": 6, "z": 25, "AA": 26, "Az": 51,
 			"BA": 52, "BZ": 77, "ZA": 26*26 + 0, "ZZ": 26*26 + 25,


### PR DESCRIPTION
This is on top of the tag `[v3.0.0]`.

This PR makes `ColIndexToLetters()` a bit simpler. The code comes from another repo, which is credited in a comment, and that repo has an MIT license.

(and I agree, xls column names are weird)