### PR TITLE
fix recover for readSheetFromFile #570

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -615,6 +615,11 @@ func readSheetViews(xSheetViews xlsxSheetViews) []SheetView {
 // readSheetsFromZipFile will spawn an instance of this function per
 // sheet and get the results back on the provided channel.
 func readSheetFromFile(rsheet xlsxSheet, fi *File, sheetXMLMap map[string]string, rowLimit int) (sheet *Sheet, errRes error) {
+	defer func() {
+		if x := recover(); x != nil {
+			errRes = errors.New(fmt.Sprint(x))
+		}
+	}()
 
 	wrap := func(err error) (*Sheet, error) {
 		return nil, fmt.Errorf("readSheetFromFile: %w", err)


### PR DESCRIPTION
[painc_test.xlsx](https://github.com/tealeg/xlsx/files/4699273/painc_test.xlsx)


```go
filePath := "./painc_test.xlsx"
f, err := xlsx3.OpenFile(filePath, xlsx3.RowLimit(100))
if err != nil {
    return err
}
```


```
panic: runtime error: index out of range [5] with length 5

goroutine 7 [running]:
github.com/tealeg/xlsx/v3.readRowsFromSheet(0xc00011f0e0, 0xc0000b4080, 0xc00026ed80, 0x2af8, 0x0, 0x0)
        /Users/yunzhanghu162/go/pkg/mod/github.com/tealeg/xlsx/v3@v3.0.0/lib.go:627 +0xd11
github.com/tealeg/xlsx/v3.readSheetFromFile(0xc0001d0cf0, 0xc, 0x148cf91, 0x1, 0xc0001d0d10, 0x4, 0x0, 0x0, 0xc0000b4080, 0xc000078ba0, ...)
        /Users/yunzhanghu162/go/pkg/mod/github.com/tealeg/xlsx/v3@v3.0.0/lib.go:696 +0x27c
github.com/tealeg/xlsx/v3.readSheetsFromZipFile.func2(0xc0001d0cf0, 0xc, 0x148cf91, 0x1, 0xc0001d0d10, 0x4, 0x0, 0x0, 0xc0000b4080, 0xc000078ba0, ...)
        /Users/yunzhanghu162/go/pkg/mod/github.com/tealeg/xlsx/v3@v3.0.0/lib.go:814 +0x8e
created by github.com/tealeg/xlsx/v3.readSheetsFromZipFile
        /Users/yunzhanghu162/go/pkg/mod/github.com/tealeg/xlsx/v3@v3.0.0/lib.go:813 +0x6a6
exit status 2
```

