### PR TITLE
Emit mergeCells after sheetData for Excel

### DIFF
--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -332,7 +332,7 @@ type xlsxMergeCell struct {
 }
 
 type xlsxMergeCells struct {
-	XMLName  xml.Name                 //`xml:"mergeCells,omitempty"`
+	XMLName  xml.Name                 `xml:"mergeCells,omitempty"`
 	Count    int                      `xml:"count,attr,omitempty"`
 	Cells    []xlsxMergeCell          `xml:"mergeCell,omitempty"`
 	CellsMap map[string]xlsxMergeCell `xml:"-"`
@@ -594,9 +594,12 @@ func emitStructAsXML(v reflect.Value, name, xmlNS string) (xmlwriter.Elem, error
 				Name:  "xmlns",
 				Value: xmlNS,
 			})
-		case "SheetData":
-			// Skip SheetData here, we explicitly generate
-			// this in writeXML below
+		case "SheetData", "MergeCells":
+			// Skip SheetData here, we explicitly generate this in writeXML below
+			// Microsoft Excel considers a mergeCells element before a sheetData element to be
+			// an error and will fail to open the document, so we'll be back with this data
+			// from writeXml later (but we'll call it OutputMergeCells to make it past this case.)
+
 			continue
 		default:
 			if fv.Kind() == reflect.Ptr {
@@ -748,6 +751,16 @@ func (worksheet *xlsxWorksheet) WriteXML(xw *xmlwriter.Writer, s *Sheet, styles 
 
 		}, SkipEmptyRows),
 		xw.EndElem("sheetData"),
+		func() error {
+			if worksheet.MergeCells != nil {
+				mergeCells, err := emitStructAsXML(reflect.ValueOf(worksheet.MergeCells), "OutputMergeCells", "")
+				if err != nil {
+					return err
+				}
+				return xw.Write(mergeCells)
+			}
+			return nil
+		}(),
 		xw.EndElem(output.Name),
 		xw.Flush(),
 	)


### PR DESCRIPTION
Microsoft Excel will fail to parse a worksheet with a mergeCells element that occurs before the sheetData element.

The following test code generates the error `Replaced Part: /xl/worksheets/sheet1.xml part with XML error.  Load error. Line 2, column 757.` when attempting to open & repair a workbook generated with the following code:
```go
func main() {
	xls := xlsx.NewFile()
	sht, _ := xls.AddSheet("sheet1")
	row := sht.AddRow()
	cell := row.AddCell()
	cell.Value = "test"
	cell.Merge(1, 0)
	path := "merged-broken.xlsx"
	xls.Save(path)
}
```