### PR TITLE
Rows and Cells can report their coordinates

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -479,3 +479,13 @@ func (c *Cell) FormattedValue() (string, error) {
 func (c *Cell) SetDataValidation(dd *xlsxDataValidation) {
 	c.DataValidation = dd
 }
+
+// GetCoordinates returns a pair of integers representing the
+// cartesian coorindates of the Cell within the Sheet.  The
+// coordinates are zero based and a returned in order x,y where x is
+// the Column number and y is the Row number.  If you need to convert
+// these numbers to a Excel cellID (i.e. B15) then please see the
+// GetCellIDStringFromCoords function.
+func (c *Cell) GetCoordinates() (int, int) {
+	return c.num, c.Row.num
+}

--- a/cell_test.go
+++ b/cell_test.go
@@ -818,6 +818,26 @@ func TestCell(t *testing.T) {
 		}
 	})
 
+	// Test that GetCoordinates returns accurate numbers..
+	csRunO(c, "GetCoordinates", func(c *qt.C, option FileOption) {
+		file := NewFile(option)
+		sheet, _ := file.AddSheet("Test")
+		row := sheet.AddRow()
+		cell := row.AddCell()
+		x, y := cell.GetCoordinates()
+		c.Assert(x, qt.Equals, 0)
+		c.Assert(y, qt.Equals, 0)
+		cell = row.AddCell()
+		x, y = cell.GetCoordinates()
+		c.Assert(x, qt.Equals, 1)
+		c.Assert(y, qt.Equals, 0)
+		row = sheet.AddRow()
+		cell = row.AddCell()
+		x, y = cell.GetCoordinates()
+		c.Assert(x, qt.Equals, 0)
+		c.Assert(y, qt.Equals, 1)
+	})
+
 }
 
 // formattedValueChecker removes all the boilerplate for testing Cell.FormattedValue

--- a/row.go
+++ b/row.go
@@ -16,6 +16,11 @@ type Row struct {
 	cells        []*Cell // the cells
 }
 
+// GetCoordinate returns the y coordinate of the row (the row number). This number is zero based, i.e. the Excel CellID "A1" is in Row 0, not Row 1.
+func (r *Row) GetCoordinate() int {
+	return r.num
+}
+
 // SetHeight sets the height of the Row in PostScript points
 func (r *Row) SetHeight(ht float64) {
 	r.height = ht


### PR DESCRIPTION
Fixes #586 

You may now use:
`Cell.GetCoordinates()`
`Row.GetCoordinate()`