### PR TITLE
Fixes internal links

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -320,9 +320,17 @@ func (c *Cell) SetInt(n int) {
 // SetHyperlink sets this cell to contain the given hyperlink, displayText and tooltip.
 // If the displayText or tooltip are an empty string, they will not be set.
 // The hyperlink provided must be a valid URL starting with http:// or https:// or
-// excel will not recognize it as an external link.
+// excel will not recognize it as an external link. All other hyperlink formats will be
+// treated as internal link between sheets. Official format in form of `#Sheet!A123`.
+// Maximum number of hyperlinks per sheet is 65530, according to specification.
 func (c *Cell) SetHyperlink(hyperlink string, displayText string, tooltip string) {
-	c.Hyperlink = Hyperlink{Link: hyperlink}
+	h := strings.ToLower(hyperlink)
+	if strings.HasPrefix(h, "http:") || strings.HasPrefix(h, "https://") {
+		c.Hyperlink = Hyperlink{Link: hyperlink}
+	} else {
+		c.Hyperlink = Hyperlink{Link: hyperlink, Location: hyperlink}
+	}
+
 	c.SetString(hyperlink)
 	c.Row.Sheet.addRelation(RelationshipTypeHyperlink, hyperlink, RelationshipTargetModeExternal)
 	if displayText != "" {


### PR DESCRIPTION
Official format for internal links is in form of `#Sheet!A123`.
Maximum number of hyperlinks per sheet is 65530, according to specification.