### PR TITLE
support m

### DIFF
--- a/format_code.go
+++ b/format_code.go
@@ -537,6 +537,7 @@ func (fullFormat *parsedNumberFormat) parseTime(value string, date1904 bool) (st
 		{"mm", "01"},
 		{"am/pm", "pm"},
 		{"m/", "1/"},
+		{"m", "1"},
 		{"%%%%", "January"},
 		{"&&&&", "Monday"},
 	}


### PR DESCRIPTION
due to "m" means "Month as a number without leading zeros (1-12)" in excel date code, see: https://www.ozgrid.com/Excel/CustomFormats.htm