### PR TITLE
Check currentRow is set on sheet before persisting it (#644)

### DIFF
--- a/file.go
+++ b/file.go
@@ -441,10 +441,12 @@ func (f *File) MarshallParts(zipWriter *zip.Writer) error {
 		return wrap(err)
 	}
 	for _, sheet := range f.Sheets {
-		// Make sure we don't lose the current state!
-		err := sheet.cellStore.WriteRow(sheet.currentRow)
-		if err != nil {
-			return wrap(err)
+		if sheet.currentRow != nil {
+			// Make sure we don't lose the current state!
+			err := sheet.cellStore.WriteRow(sheet.currentRow)
+			if err != nil {
+				return wrap(err)
+			}
 		}
 
 		xSheetRels := sheet.makeXLSXSheetRelations()


### PR DESCRIPTION
This PR stops the a panic on file write when visiting a sheet where the currentRow isn't set (because it hasn't been visited prior to that). 

Fixes #644 