### PR TITLE
fix: Switched up black and white color codes

### DIFF
--- a/style.go
+++ b/style.go
@@ -17,8 +17,8 @@ const (
 	RGB_Dark_Green  = "FF006100"
 	RGB_Light_Red   = "FFFFC7CE"
 	RGB_Dark_Red    = "FF9C0006"
-	RGB_White       = "00000000"
-	RGB_Black       = "FFFFFFFF"
+	RGB_White       = "FFFFFFFF"
+	RGB_Black       = "00000000"
 )
 
 const (


### PR DESCRIPTION
Excel defines black and white as RGB(0,0,0) and RGB(255,255,255) respectively. 

For RGB_Black and RGB_White to work as expected, we have to switch up their color code.