### PR TITLE
Fix empty cells in Mac OS Numbers

### DIFF
--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -692,6 +692,8 @@ func (worksheet *xlsxWorksheet) makeXlsxRowFromRow(row *Row, styles *xlsxStyleSh
 				xC.V = strconv.Itoa(refTable.AddString(cell.Value))
 			} else if len(cell.RichText) > 0 {
 				xC.V = strconv.Itoa(refTable.AddRichText(cell.RichText))
+			} else {
+				xC.V = strconv.Itoa(refTable.AddString(""))
 			}
 			xC.T = "s"
 		case CellTypeNumeric:


### PR DESCRIPTION
When no string value is set for a cell, Numbers copies the value from cell A1. Setting an empty string fixes the issue.

This fixes #594. I did see that the release notes for v3.2.1 mentioned this being fixed already, but I'm still seeing the Numbers issue on current master branch.