### PR TITLE
fix: testing temp files cleanup

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -298,7 +298,7 @@ func (dvr *DiskVRow) ForEachCell(cvf CellVisitorFunc, option ...CellVisitorOptio
 				return err
 			}
 		}
-		
+
 		err = fn(ci, cell)
 		if err != nil {
 			return err
@@ -345,6 +345,8 @@ func UseDiskVCellStore(f *File) {
 	f.cellStoreConstructor = NewDiskVCellStore
 }
 
+const cellStorePrefix = "cellstore"
+
 // NewDiskVCellStore is a CellStoreConstructor than returns a
 // CellStore in terms of DiskV.
 func NewDiskVCellStore() (CellStore, error) {
@@ -352,7 +354,7 @@ func NewDiskVCellStore() (CellStore, error) {
 		buf: bytes.NewBuffer([]byte{}),
 	}
 
-	dir, err := ioutil.TempDir("", "cellstore"+generator.Hex128())
+	dir, err := ioutil.TempDir("", cellStorePrefix+generator.Hex128())
 	if err != nil {
 		return nil, err
 	}

--- a/testutil.go
+++ b/testutil.go
@@ -1,6 +1,31 @@
 package xlsx
 
-import qt "github.com/frankban/quicktest"
+import (
+	"os"
+	"path/filepath"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// cleanTempDir removes all the temporary files from NewDiskVCellStore
+func cleanTempDir(c *qt.C) {
+	tempDirBase := os.TempDir()
+
+	globPattern := tempDirBase + "/" + cellStorePrefix + "*"
+
+	dirs, err := filepath.Glob(globPattern)
+	if err != nil {
+		c.Logf("Cannot glob files of %s", globPattern)
+		c.FailNow()
+	}
+
+	for _, directory := range dirs {
+		if err = os.RemoveAll(directory); err != nil {
+			c.Logf("Cannot remove files of %s", directory)
+			c.FailNow()
+		}
+	}
+}
 
 // csRunC will run the given test function with all available
 // CellStoreConstructors.  You must take care of setting the
@@ -15,6 +40,10 @@ func csRunC(c *qt.C, description string, test func(c *qt.C, constructor CellStor
 			test(c, NewDiskVCellStore)
 		})
 	})
+
+	if !c.Failed() {
+		cleanTempDir(c)
+	}
 }
 
 // csRunO will run the given test function with all available CellStore FileOptions, you must takes care of passing the FileOption to the appropriate method.
@@ -27,4 +56,9 @@ func csRunO(c *qt.C, description string, test func(c *qt.C, option FileOption)) 
 			test(c, UseDiskVCellStore)
 		})
 	})
+
+	if !c.Failed() {
+		cleanTempDir(c)
+	}
+
 }


### PR DESCRIPTION
- When testing, files are piling up quickly in the temp directory, now
  files are cleaned up after each run (if the test has not failed).

ISSUE: NONE