### PR TITLE
Fix support for capitalised date formats

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -379,7 +379,7 @@ func (c *Cell) SetHyperlink(hyperlink string, displayText string, tooltip string
 	} else {
 		c.Hyperlink = Hyperlink{Link: hyperlink, Location: hyperlink}
 	}
-  c.SetString(hyperlink)
+	c.SetString(hyperlink)
 	c.Row.Sheet.addRelation(RelationshipTypeHyperlink, hyperlink, RelationshipTargetModeExternal)
 	if displayText != "" {
 		c.Hyperlink.DisplayString = displayText

--- a/cell_test.go
+++ b/cell_test.go
@@ -542,6 +542,12 @@ func TestCell(t *testing.T) {
 			fvc.Equals(smallCell, expect2[0:tlen-i])
 		}
 
+		cell.NumFmt = "YYYY-MM-DD"
+		fvc.Equals(cell, "2003-11-22")
+
+		cell.NumFmt = "yyyy-mm-dd"
+		fvc.Equals(cell, "2003-11-22")
+
 		cell.NumFmt = "yyyy\\-mm\\-dd"
 		fvc.Equals(cell, "2003\\-11\\-22")
 

--- a/diskv_test.go
+++ b/diskv_test.go
@@ -644,7 +644,7 @@ line!`)
 
 		cell := &Cell{
 			RichText: []RichTextRun{
-				RichTextRun{
+				{
 					Font: &RichTextFont{Bold: true},
 					Text: "rich text",
 				},
@@ -897,10 +897,10 @@ line!`)
 		buf := bytes.NewBufferString("")
 
 		rt1 := []RichTextRun{
-			RichTextRun{
+			{
 				Text: "Text1",
 			},
-			RichTextRun{
+			{
 				Font: &RichTextFont{
 					Italic: true,
 				},

--- a/format_code.go
+++ b/format_code.go
@@ -417,7 +417,7 @@ var formattingCharacters = []string{"0/", "#/", "?/", "E-", "E+", "e-", "e+", "0
 // redundant here: ee, gg, ggg, rr, ss, mm, hh, yyyy, dd, ddd, dddd, mm, mmm, mmmm, mmmmm, ss.0000, ss.000, ss.00, ss.0
 // The .00 type format is very tricky, because it only counts if it comes after ss or s or [ss] or [s]
 // .00 is actually a valid number format by itself.
-var timeFormatCharacters = []string{"M", "D", "Y", "m", "d", "yy", "h", "m", "AM/PM", "A/P", "am/pm", "a/p", "r", "g", "e", "b1", "b2", "[hh]", "[h]", "[mm]", "[m]",
+var timeFormatCharacters = []string{"M", "D", "Y", "YY", "YYYY", "MM", "yyyy", "m", "d", "yy", "h", "m", "AM/PM", "A/P", "am/pm", "a/p", "r", "g", "e", "b1", "b2", "[hh]", "[h]", "[mm]", "[m]",
 	"s.0000", "s.000", "s.00", "s.0", "s", "[ss].0000", "[ss].000", "[ss].00", "[ss].0", "[ss]", "[s].0000", "[s].000", "[s].00", "[s].0", "[s]", "上", "午", "下"}
 
 func splitFormatAndSuffixFormat(format string) (string, string) {
@@ -530,22 +530,36 @@ func (fullFormat *parsedNumberFormat) parseTime(value string, date1904 bool) (st
 	// turn them to what they should actually be.
 	// Based off: http://www.ozgrid.com/Excel/CustomFormats.htm
 	replacements := []struct{ xltime, gotime string }{
+		{"YYYY", "2006"},
 		{"yyyy", "2006"},
+		{"YY", "06"},
 		{"yy", "06"},
+		{"MMMM", "%%%%"},
 		{"mmmm", "%%%%"},
+		{"DDDD", "&&&&"},
 		{"dddd", "&&&&"},
+		{"DD", "02"},
 		{"dd", "02"},
+		{"D", "2"},
 		{"d", "2"},
+		{"MMM", "Jan"},
 		{"mmm", "Jan"},
+		{"MMSS", "0405"},
 		{"mmss", "0405"},
+		{"SS", "05"},
 		{"ss", "05"},
+		{"MM:", "04:"},
 		{"mm:", "04:"},
+		{":MM", ":04"},
 		{":mm", ":04"},
+		{"MM", "01"},
 		{"mm", "01"},
+		{"AM/PM", "pm"},
 		{"am/pm", "pm"},
+		{"M/", "1/"},
 		{"m/", "1/"},
 		{"%%%%", "January"},
-		{"&&&&", "Monday"},
+		{"&&&&", "Monday"},                
 	}
 	// It is the presence of the "am/pm" indicator that determins
 	// if this is a 12 hour or 24 hours time format, not the

--- a/format_code.go
+++ b/format_code.go
@@ -559,7 +559,7 @@ func (fullFormat *parsedNumberFormat) parseTime(value string, date1904 bool) (st
 		{"M/", "1/"},
 		{"m/", "1/"},
 		{"%%%%", "January"},
-		{"&&&&", "Monday"},                
+		{"&&&&", "Monday"},
 	}
 	// It is the presence of the "am/pm" indicator that determins
 	// if this is a 12 hour or 24 hours time format, not the

--- a/lib.go
+++ b/lib.go
@@ -82,7 +82,7 @@ func ColIndexToLetters(n int) string {
 
 	for n > 0 {
 		n -= 1
-		l := n%26
+		l := n % 26
 		s = string('A'+rune(l)) + s
 		n /= 26
 	}

--- a/memory_test.go
+++ b/memory_test.go
@@ -82,11 +82,11 @@ func TestMemoryCellStore(t *testing.T) {
 		}
 
 		rt := []RichTextRun{
-			RichTextRun{
+			{
 				Font: &RichTextFont{Bold: true},
 				Text: "bold",
 			},
-			RichTextRun{
+			{
 				Text: "normal",
 			},
 		}

--- a/reftable_test.go
+++ b/reftable_test.go
@@ -120,7 +120,7 @@ func (s *RefTableSuite) TestMakeXLSXSST(c *C) {
 	refTable.AddString("Foo")
 	refTable.AddString("Bar")
 	refTable.AddRichText([]RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -128,7 +128,7 @@ func (s *RefTableSuite) TestMakeXLSXSST(c *C) {
 			},
 			Text: "Text1",
 		},
-		RichTextRun{
+		{
 			Text: "Text2",
 		},
 	})
@@ -153,7 +153,7 @@ func (s *RefTableSuite) TestMarshalSST(c *C) {
 	refTable := NewSharedStringRefTable()
 	refTable.AddString("Foo")
 	refTable.AddRichText([]RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -161,7 +161,7 @@ func (s *RefTableSuite) TestMarshalSST(c *C) {
 			},
 			Text: "Text1",
 		},
-		RichTextRun{
+		{
 			Text: "Text2",
 		},
 	})
@@ -210,7 +210,7 @@ func (s *RefTableSuite) TestRefTableReadAddRichText(c *C) {
 	refTable := NewSharedStringRefTable()
 	refTable.isWrite = false
 	index1 := refTable.AddRichText([]RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -220,7 +220,7 @@ func (s *RefTableSuite) TestRefTableReadAddRichText(c *C) {
 		},
 	})
 	index2 := refTable.AddRichText([]RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -248,7 +248,7 @@ func (s *RefTableSuite) TestRefTableWriteAddRichText(c *C) {
 	refTable := NewSharedStringRefTable()
 	refTable.isWrite = true
 	index1 := refTable.AddRichText([]RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -258,7 +258,7 @@ func (s *RefTableSuite) TestRefTableWriteAddRichText(c *C) {
 		},
 	})
 	index2 := refTable.AddRichText([]RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,

--- a/richtext_test.go
+++ b/richtext_test.go
@@ -104,7 +104,7 @@ func (s *RichTextSuite) TestRichTextRunEquals(c *C) {
 
 func (s *RichTextSuite) TestRichTextToXml(c *C) {
 	rtr := []RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Name:      "Font",
 				Size:      12.345,
@@ -119,7 +119,7 @@ func (s *RichTextSuite) TestRichTextToXml(c *C) {
 			},
 			Text: "Bold",
 		},
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -127,7 +127,7 @@ func (s *RichTextSuite) TestRichTextToXml(c *C) {
 			},
 			Text: "Italic",
 		},
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Family:  RichTextFontFamilyUnspecified,
 				Charset: RichTextCharsetUnspecified,
@@ -135,11 +135,11 @@ func (s *RichTextSuite) TestRichTextToXml(c *C) {
 			},
 			Text: "Strike",
 		},
-		RichTextRun{
+		{
 			Font: &RichTextFont{},
 			Text: "Empty",
 		},
-		RichTextRun{
+		{
 			Text: "No Font",
 		},
 	}
@@ -226,7 +226,7 @@ func (s *RichTextSuite) TestRichTextToXml(c *C) {
 
 func (s *RichTextSuite) TestXmlToRichText(c *C) {
 	xmlr := []xlsxR{
-		xlsxR{
+		{
 			RPr: &xlsxRunProperties{
 				RFont:     &xlsxVal{Val: "Font"},
 				Charset:   &xlsxIntVal{Val: int(RichTextCharsetGreek)},
@@ -246,7 +246,7 @@ func (s *RichTextSuite) TestXmlToRichText(c *C) {
 			},
 			T: xlsxT{Text: "Bold"},
 		},
-		xlsxR{
+		{
 			RPr: &xlsxRunProperties{
 				RFont:     nil,
 				Charset:   nil,
@@ -266,7 +266,7 @@ func (s *RichTextSuite) TestXmlToRichText(c *C) {
 			},
 			T: xlsxT{Text: "Italic"},
 		},
-		xlsxR{
+		{
 			RPr: &xlsxRunProperties{
 				RFont:     nil,
 				Charset:   nil,
@@ -286,11 +286,11 @@ func (s *RichTextSuite) TestXmlToRichText(c *C) {
 			},
 			T: xlsxT{Text: "Strike"},
 		},
-		xlsxR{
+		{
 			RPr: &xlsxRunProperties{},
 			T:   xlsxT{Text: "Empty"},
 		},
-		xlsxR{
+		{
 			RPr: nil,
 			T:   xlsxT{Text: "No Font"},
 		},
@@ -358,19 +358,19 @@ func (s *RichTextSuite) TestXmlToRichText(c *C) {
 
 func (s *RichTextSuite) TestRichTextToPlainText(c *C) {
 	rt := []RichTextRun{
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Bold: true,
 			},
 			Text: "Bold",
 		},
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Italic: true,
 			},
 			Text: "Italic",
 		},
-		RichTextRun{
+		{
 			Font: &RichTextFont{
 				Strike: true,
 			},

--- a/sheet.go
+++ b/sheet.go
@@ -52,7 +52,7 @@ func NewSheetWithCellStore(name string, constructor CellStoreConstructor) (*Shee
 
 }
 
-// Remove Sheet's dependant resources - if you are done with operations on a sheet this should be called to clear down the Sheet's persistent cache.  Note: if you call this, all further read operaton on the sheet will fail - including any attempt to save the file, or dump it's contents to a byte stream.  Therefore only call this *after* you've saved your changes, of when you're done reading a sheet in a file you don't plan to persist. 
+// Remove Sheet's dependant resources - if you are done with operations on a sheet this should be called to clear down the Sheet's persistent cache.  Note: if you call this, all further read operaton on the sheet will fail - including any attempt to save the file, or dump it's contents to a byte stream.  Therefore only call this *after* you've saved your changes, of when you're done reading a sheet in a file you don't plan to persist.
 func (s *Sheet) Close() {
 	s.cellStore.Close()
 	s.cellStore = nil
@@ -412,15 +412,15 @@ func (s *Sheet) SetColWidth(min, max int, width float64) {
 // This can be use as the default scale function for the autowidth.
 // It works well with the default font sizes.
 func DefaultAutoWidth(s string) float64 {
-	return (float64(strings.Count(s, "")) + 3.0 ) * 1.2
+	return (float64(strings.Count(s, "")) + 3.0) * 1.2
 }
 
 // Tries to guess the best width for a column, based on the largest
 // cell content. A scale function needs to be provided.
-func (s *Sheet) SetColAutoWidth(colIndex int, width func (string) float64) error {
+func (s *Sheet) SetColAutoWidth(colIndex int, width func(string) float64) error {
 	s.mustBeOpen()
 	largestWidth := 0.0
-	rowVisitor := func (r *Row) error {
+	rowVisitor := func(r *Row) error {
 		cell := r.GetCell(colIndex)
 		value, err := cell.FormattedValue()
 		if err != nil {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -617,7 +617,6 @@ func TestMakeXLSXSheet(t *testing.T) {
 		c.Assert(sheet.Cols.FindColByIndex(2).Min, qt.Equals, 2)
 	})
 
-
 	csRunO(c, "SetColAutoWidth", func(c *qt.C, option FileOption) {
 		file := NewFile(option)
 		sheet, _ := file.AddSheet("Sheet1")
@@ -629,7 +628,7 @@ func TestMakeXLSXSheet(t *testing.T) {
 
 		sheet.SetColAutoWidth(0, DefaultAutoWidth)
 
-		scaleFunc := func (s string) float64 {
+		scaleFunc := func(s string) float64 {
 			return float64(strings.Count(s, "")) * 1.5
 		}
 		sheet.SetColAutoWidth(1, scaleFunc)
@@ -642,7 +641,6 @@ func TestMakeXLSXSheet(t *testing.T) {
 		c.Assert(sheet.Cols.FindColByIndex(1).Max, qt.Equals, 1)
 		c.Assert(sheet.Cols.FindColByIndex(1).Min, qt.Equals, 1)
 	})
-
 
 	csRunO(c, "SetDataValidation", func(c *qt.C, option FileOption) {
 		file := NewFile(option)

--- a/write_test.go
+++ b/write_test.go
@@ -312,7 +312,6 @@ func TestBigWrite(t *testing.T) {
 
 }
 
-
 func TestWriteFileWithUnvisitedSheets(t *testing.T) {
 	c := qt.New(t)
 
@@ -322,7 +321,7 @@ func TestWriteFileWithUnvisitedSheets(t *testing.T) {
 	csRunO(c, "Test for panic", func(c *qt.C, opt FileOption) {
 		fileToOpen := filepath.Join("testdocs", "testfile.xlsx")
 		// open an existing file
-		wbFile, err := OpenFile(fileToOpen, opt) 
+		wbFile, err := OpenFile(fileToOpen, opt)
 		c.Assert(err, qt.IsNil)
 
 		sheetName := "Tabelle1"
@@ -337,7 +336,7 @@ func TestWriteFileWithUnvisitedSheets(t *testing.T) {
 		path := filepath.Join(testDir, "test.xlsx")
 
 		// With issue 644 this line would panic
-		err = wbFile.Save(path) 
+		err = wbFile.Save(path)
 		c.Assert(err, qt.IsNil)
- 	})
+	})
 }


### PR DESCRIPTION
This PR fixes #696 

When the format code handling was rewritten, detecting capital letter forms (i.e. YYYY-MM-DD) was remembered, but substituting them for go date formats was forgotten.  This branch fixes that. 