### PR TITLE
fix datavalidation dorplist size

### DIFF
--- a/data_validation.go
+++ b/data_validation.go
@@ -3,6 +3,7 @@ package xlsx
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 type DataValidationType int
@@ -22,10 +23,10 @@ const (
 )
 
 const (
-	// dataValidationFormulaStrLen 255 characters+ 2 quotes
+	// dataValidationFormulaStrLen 255 runes + 2 quotes
 	dataValidationFormulaStrLen = 257
 	// dataValidationFormulaStrLenErr
-	dataValidationFormulaStrLenErr = "data validation must be 0-255 characters"
+	dataValidationFormulaStrLenErr = "data validation must be 0-255 runes"
 )
 
 type DataValidationErrorStyle int
@@ -107,7 +108,7 @@ func (dd *xlsxDataValidation) SetInput(title, msg *string) {
 // List validations do not work in Apple Numbers.
 func (dd *xlsxDataValidation) SetDropList(keys []string) error {
 	formula := "\"" + strings.Join(keys, ",") + "\""
-	if dataValidationFormulaStrLen < len(formula) {
+	if dataValidationFormulaStrLen < utf8.RuneCountInString(formula) {
 		return fmt.Errorf(dataValidationFormulaStrLenErr)
 	}
 	dd.Formula1 = formula


### PR DESCRIPTION
ms office allow max 255 runes in datavalidation input, not 255 bytes.