### PR TITLE
Add support for StreamCell merging and custom row heights

### DIFF
--- a/cell_test.go
+++ b/cell_test.go
@@ -573,6 +573,11 @@ func (l *CellSuite) TestFormattedValue(c *C) {
 	earlyCell.NumFmt = "m/d/yy"
 	fvc.Equals(earlyCell, "1/1/00")
 
+	cell.NumFmt = "m d yy"
+	fvc.Equals(cell, "11 22 03")
+	earlyCell.NumFmt = "m d yy"
+	fvc.Equals(earlyCell, "1 1 00")
+
 	cell.NumFmt = "m/d/yyyy"
 	fvc.Equals(cell, "11/22/2003")
 	earlyCell.NumFmt = "m/d/yyyy"

--- a/format_code.go
+++ b/format_code.go
@@ -535,7 +535,7 @@ func (fullFormat *parsedNumberFormat) parseTime(value string, date1904 bool) (st
 		{"mm:", "04:"},
 		{":mm", ":04"},
 		{"mm", "01"},
-		{"am/pm", "pm"},
+		{"am/pm", "PM"},
 		{"m/", "1/"},
 		{"m", "1"},
 		{"%%%%", "January"},
@@ -554,6 +554,8 @@ func (fullFormat *parsedNumberFormat) parseTime(value string, date1904 bool) (st
 	for _, repl := range replacements {
 		format = strings.Replace(format, repl.xltime, repl.gotime, 1)
 	}
+	// Ensure that "m" format does not clobber am/pm
+	format = strings.Replace(format, "PM", "pm", 1)
 	// If the hour is optional, strip it out, along with the
 	// possible dangling colon that would remain.
 	if val.Hour() < 1 {

--- a/lib.go
+++ b/lib.go
@@ -17,6 +17,7 @@ const (
 	fixedCellRefChar      = "$"
 	cellRangeChar         = ":"
 	externalSheetBangChar = "!"
+	cmToPostscriptPts     = 28.3464567 // Convert CM to postscript points
 )
 
 // XLSXReaderError is the standard error type for otherwise undefined
@@ -97,12 +98,12 @@ func formatColumnName(colId []int) string {
 			// range 0-25, all other numbers are 1-26,
 			// hence we use a differente offset for the
 			// last part.
-			result += string(part + 65)
+			result += string(rune(part + 65))
 		} else {
 			// Don't output leading 0s, as there is no
 			// representation of 0 in this format.
 			if part > 0 {
-				result += string(part + 64)
+				result += string(rune(part + 64))
 			}
 		}
 	}

--- a/row.go
+++ b/row.go
@@ -15,7 +15,7 @@ func (r *Row) SetHeight(ht float64) {
 }
 
 func (r *Row) SetHeightCM(ht float64) {
-	r.Height = ht * 28.3464567 // Convert CM to postscript points
+	r.Height = ht * cmToPostscriptPts
 	r.isCustom = true
 }
 

--- a/stream_cell.go
+++ b/stream_cell.go
@@ -10,6 +10,16 @@ type StreamCell struct {
 	cellData  string
 	cellStyle StreamStyle
 	cellType  CellType
+	HMerge    int
+	VMerge    int
+}
+
+// Merge with other cells, horizontally and/or vertically. The merged cell should not extend past the last column of the
+// streamed sheet as specified by the first row. This does not verify that merged cells do not overlap nor does it
+// verify that vertical merges are within the bounds of the number of rows in the sheet.
+func (c *StreamCell) Merge(hcells, vcells int) {
+	c.HMerge = hcells
+	c.VMerge = vcells
 }
 
 // NewStreamCell creates a new cell containing the given data with the given style and type.

--- a/stream_cell_test.go
+++ b/stream_cell_test.go
@@ -1,0 +1,23 @@
+package xlsx
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type StreamCellSuite struct{}
+
+var _ = Suite(&StreamCellSuite{})
+
+// Test we can merge StreamCells
+func (r *StreamCellSuite) TestMerge(c *C) {
+	cell := NewStringStreamCell("First")
+
+	c.Assert(cell.HMerge, Equals, 0)
+	c.Assert(cell.VMerge, Equals, 0)
+
+	cell.Merge(3, 4)
+
+	c.Assert(cell.HMerge, Equals, 3)
+	c.Assert(cell.VMerge, Equals, 4)
+}
+

--- a/stream_file_builder.go
+++ b/stream_file_builder.go
@@ -67,7 +67,7 @@ const (
 
 var BuiltStreamFileBuilderError = errors.New("StreamFileBuilder has already been built, functions may no longer be used")
 
-// NewStreamFileBuilder creates an StreamFileBuilder that will write to the the provided io.writer
+// NewStreamFileBuilder creates an StreamFileBuilder that will write to the provided io.writer
 func NewStreamFileBuilder(writer io.Writer) *StreamFileBuilder {
 	return &StreamFileBuilder{
 		zipWriter:          zip.NewWriter(writer),

--- a/stream_row.go
+++ b/stream_row.go
@@ -1,0 +1,21 @@
+package xlsx
+
+type StreamRow struct {
+	Cells    []StreamCell
+	Height   float64
+	isCustom bool
+}
+
+func (r *StreamRow) SetHeight(ht float64) {
+	r.Height = ht
+	r.isCustom = true
+}
+
+func (r *StreamRow) SetHeightCM(ht float64) {
+	r.Height = ht * cmToPostscriptPts
+	r.isCustom = true
+}
+
+func NewStreamRow(cells []StreamCell) StreamRow {
+	return StreamRow{Cells: cells}
+}

--- a/stream_row_test.go
+++ b/stream_row_test.go
@@ -1,0 +1,40 @@
+package xlsx
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type StreamRowSuite struct{}
+
+var _ = Suite(&StreamRowSuite{})
+
+// Test we can create a new StreamRow
+func (r *StreamRowSuite) TestNewStreamRow(c *C) {
+	row := NewStreamRow([]StreamCell{})
+	c.Assert(len(row.Cells), Equals, 0)
+
+	c1 := NewStringStreamCell("First")
+	c2 := NewStringStreamCell("Second")
+	row2 := NewStreamRow([]StreamCell{c1, c2})
+	c.Assert(len(row2.Cells), Equals, 2)
+}
+
+// Test we can set a custom height on a StreamRow
+func (r *StreamRowSuite) TestSetRowHeight(c *C) {
+	row := NewStreamRow([]StreamCell{})
+
+	c.Assert(row.isCustom, Equals, false)
+
+	row.SetHeight(123)
+	c.Assert(row.isCustom, Equals, true)
+	c.Assert(row.Height, Equals, float64(123))
+}
+
+// Test we can set a custom height on a StreamRow in cm
+func (r *StreamRowSuite) TestSetRowHeightCM(c *C) {
+	row := NewStreamRow([]StreamCell{})
+
+	row.SetHeightCM(1)
+	c.Assert(row.isCustom, Equals, true)
+	c.Assert(row.Height, Equals, cmToPostscriptPts)
+}

--- a/stream_style_test.go
+++ b/stream_style_test.go
@@ -426,11 +426,13 @@ func (s *StreamStyleSuite) TestDates(t *C) {
 		filePath = fmt.Sprintf("Workbook_Date_test.xlsx")
 	}
 
+	testDate := time.Date(2022, 01, 01, 12, 34, 56, 0, time.UTC)
+
 	sheetNames := []string{"Sheet1"}
 	workbookData := [][][]StreamCell{
 		{
 			{NewStringStreamCell("Date:")},
-			{NewDateStreamCell(time.Now())},
+			{NewDateStreamCell(testDate)},
 		},
 	}
 
@@ -461,7 +463,7 @@ func (s *StreamStyleSuite) TestDates(t *C) {
 	}
 
 	expectedWorkbookDataStrings[0][0] = append(expectedWorkbookDataStrings[0][0], workbookData[0][0][0].cellData)
-	year, month, day := time.Now().Date()
+	year, month, day := testDate.Date()
 	monthString := strconv.Itoa(int(month))
 	if int(month) < 10 {
 		monthString = "0" + monthString
@@ -765,7 +767,6 @@ func (s *StreamStyleSuite) TestNoStylesWriteSError(t *C) {
 	if err.Error() != "trying to make use of a style that has not been added" {
 		t.Fatal("Error differs from expected error")
 	}
-
 
 }
 

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -302,7 +302,7 @@ type xlsxMergeCell struct {
 }
 
 type xlsxMergeCells struct {
-	XMLName xml.Name        //`xml:"mergeCells,omitempty"`
+	XMLName xml.Name        `xml:"mergeCells,omitempty"`
 	Count   int             `xml:"count,attr,omitempty"`
 	Cells   []xlsxMergeCell `xml:"mergeCell,omitempty"`
 }


### PR DESCRIPTION
Adds support for `Merge()` and `Height()` for `StreamCell`/`StreamRow`.

To merge a StreamCell, call `Merge(h, v)` with the number of extra cells to merge in each direction. Note: does not do any advanced bounds/overlap checking, just ensures that it doesn't go beyond the width of the stream sheet.

To set a custom height, create a `StreamRow` and call `Height()`. It must be written to the sheet with `WriteRowS()`.

This PR also resolves a few tests that were broken on the tip of the v1 branch related to styles and date formatting.