### PR TITLE
Upgrade GitHub CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
 
     - name: Set up Go 1.14
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.14
+        go-version: 1.20
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.14
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Set up Go 1.20
       uses: actions/setup-go@v4
       with:
         go-version: 1.20
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.20
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: '1.20'
       id: go
 
     - name: Get dependencies

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,12 +23,7 @@ jobs:
       id: go
 
     - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      run: go mod download
 
     - name: Build
       run: go build -v .


### PR DESCRIPTION
Modernize GitHub Actions workflow:
* build with Go 1.20
* drop use of `dep`
* upgrade actions: [`checkout@v3`](https://github.com/actions/checkout), [`setup-go@v4`](https://github.com/actions/setup-go)