### PR TITLE
Enable parallel testing

### DIFF
--- a/data_validation_test.go
+++ b/data_validation_test.go
@@ -8,17 +8,18 @@ import (
 )
 
 func TestDataValidation(t *testing.T) {
-	var file *File
-	var sheet *Sheet
-	var row *Row
-	var cell *Cell
-	var err error
-	var title = "cell"
-	var msg = "cell msg"
 
 	c := qt.New(t)
 
 	csRunO(c, "DataValidation", func(c *qt.C, option FileOption) {
+		var file *File
+		var sheet *Sheet
+		var row *Row
+		var cell *Cell
+		var err error
+		var title = "cell"
+		var msg = "cell msg"
+
 		file = NewFile(option)
 		sheet, err = file.AddSheet("Sheet1")
 		c.Assert(err, qt.Equals, nil)

--- a/testutil.go
+++ b/testutil.go
@@ -34,31 +34,38 @@ func csRunC(c *qt.C, description string, test func(c *qt.C, constructor CellStor
 
 	c.Run(description, func(c *qt.C) {
 		c.Run("MemoryCellStore", func(c *qt.C) {
+			c.Parallel()
 			test(c, NewMemoryCellStore)
 		})
 		c.Run("DiskVCellStore", func(c *qt.C) {
+			c.Parallel()
 			test(c, NewDiskVCellStore)
 		})
 	})
 
-	if !c.Failed() {
-		cleanTempDir(c)
-	}
+	c.TB.Cleanup(func() {
+		if !c.Failed() {
+			cleanTempDir(c)
+		}
+	})
 }
 
 // csRunO will run the given test function with all available CellStore FileOptions, you must takes care of passing the FileOption to the appropriate method.
 func csRunO(c *qt.C, description string, test func(c *qt.C, option FileOption)) {
 	c.Run(description, func(c *qt.C) {
 		c.Run("MemoryCellStore", func(c *qt.C) {
+			c.Parallel()
 			test(c, UseMemoryCellStore)
 		})
 		c.Run("DiskVCellStore", func(c *qt.C) {
+			c.Parallel()
 			test(c, UseDiskVCellStore)
 		})
 	})
 
-	if !c.Failed() {
-		cleanTempDir(c)
-	}
-
+	c.TB.Cleanup(func() {
+		if !c.Failed() {
+			cleanTempDir(c)
+		}
+	})
 }


### PR DESCRIPTION
Enable parallel testing to reduce test clock time.

Parallelism is not very aggressive for now because I found an issue with `quicktest` handling of Parallel.

```
go test -parallel=10
```