### PR TITLE
use random file name for RoundTripFileWithNoSheetCols test

### DIFF
--- a/lib_test.go
+++ b/lib_test.go
@@ -3,7 +3,9 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
+	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1357,11 +1359,12 @@ func TestLib(t *testing.T) {
 	csRunO(c, "RoundTripFileWithNoSheetCols", func(c *qt.C, option FileOption) {
 		originalXlFile, err := OpenFile("testdocs/original.xlsx", option)
 		c.Assert(err, qt.IsNil)
-		err = originalXlFile.Save("testdocs/after_write.xlsx")
+		destFile := "testdocs/" + strconv.Itoa(rand.Int()) + ".xlsx"
+		err = originalXlFile.Save(destFile)
 		c.Assert(err, qt.IsNil)
-		_, err = OpenFile("testdocs/after_write.xlsx", option)
+		_, err = OpenFile(destFile)
 		c.Assert(err, qt.IsNil)
-		err = os.Remove("testdocs/after_write.xlsx")
+		err = os.Remove(destFile)
 		c.Assert(err, qt.IsNil)
 	})
 


### PR DESCRIPTION
In my test, RoundTripFileWithNoSheetCols  fails with error `e"OpenFile: open testdocs/after_write.xlsx: no such file or directory"` This is most likely due to the parallel test runs called by csRunO that try to write and remove the files concurrently. [Failed error attached](https://github.com/tealeg/xlsx/files/12566807/failedTest.txt)

By choosing a random filename,
each test create/write and removes its own file,
allowing this test to pass as expected.
