### PR TITLE
switch gopkg.in/check.v1 to quicktest in some test files

### DIFF
--- a/col_test.go
+++ b/col_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	. "gopkg.in/check.v1"
 )
 
 var notNil = qt.Not(qt.IsNil)
@@ -83,14 +82,13 @@ func TestCol(t *testing.T) {
 
 type ColStoreSuite struct{}
 
-var _ = Suite(&ColStoreSuite{})
-
-func (css *ColStoreSuite) TestAddRootNode(c *C) {
+func TestAddRootNode(t *testing.T) {
 	col := &Col{Min: 1, Max: 1}
 	cs := ColStore{}
 	cs.Add(col)
-	c.Assert(cs.Len, Equals, 1)
-	c.Assert(cs.Root.Col, Equals, col)
+	c := qt.New(t)
+	c.Assert(cs.Len, qt.Equals, 1)
+	c.Assert(cs.Root.Col, qt.Equals, col)
 }
 
 func TestMakeWay(t *testing.T) {
@@ -430,16 +428,17 @@ func TestMakeWay(t *testing.T) {
 
 }
 
-func (css *ColStoreSuite) TestFindNodeForCol(c *C) {
+func TestFindNodeForCol(t *testing.T) {
+	c := qt.New(t)
 
 	assertNodeFound := func(cs *ColStore, num int, col *Col) {
 		node := cs.findNodeForColNum(num)
 		if col == nil {
-			c.Assert(node, IsNil)
+			c.Assert(node, qt.IsNil)
 			return
 		}
-		c.Assert(node, NotNil)
-		c.Assert(node.Col, Equals, col)
+		c.Assert(node, qt.IsNotNil)
+		c.Assert(node.Col, qt.Equals, col)
 	}
 
 	cs := &ColStore{}
@@ -470,17 +469,18 @@ func (css *ColStoreSuite) TestFindNodeForCol(c *C) {
 	assertNodeFound(cs, 126, nil)
 }
 
-func (css *ColStoreSuite) TestRemoveNode(c *C) {
+func TestRemoveNode(t *testing.T) {
+	c := qt.New(t)
 
 	assertChain := func(cs *ColStore, chain []*Col) {
 		node := cs.Root
 		for _, col := range chain {
-			c.Assert(node, NotNil)
-			c.Assert(node.Col.Min, Equals, col.Min)
-			c.Assert(node.Col.Max, Equals, col.Max)
+			c.Assert(node, qt.IsNotNil)
+			c.Assert(node.Col.Min, qt.Equals, col.Min)
+			c.Assert(node.Col.Max, qt.Equals, col.Max)
 			node = node.Next
 		}
-		c.Assert(node, IsNil)
+		c.Assert(node, qt.IsNil)
 	}
 
 	cs := &ColStore{}
@@ -494,18 +494,19 @@ func (css *ColStoreSuite) TestRemoveNode(c *C) {
 	cs.Add(col3)
 	col4 := &Col{Min: 5, Max: 5}
 	cs.Add(col4)
-	c.Assert(cs.Len, Equals, 5)
+	c.Assert(cs.Len, qt.Equals, 5)
 
 	cs.removeNode(cs.findNodeForColNum(5))
-	c.Assert(cs.Len, Equals, 4)
+	c.Assert(cs.Len, qt.Equals, 4)
 	assertChain(cs, []*Col{col0, col1, col2, col3})
 
 	cs.removeNode(cs.findNodeForColNum(1))
-	c.Assert(cs.Len, Equals, 3)
+	c.Assert(cs.Len, qt.Equals, 3)
 	assertChain(cs, []*Col{col1, col2, col3})
 }
 
-func (css *ColStoreSuite) TestForEach(c *C) {
+func TestForEach(t *testing.T) {
+	c := qt.New(t)
 	cs := &ColStore{}
 	col0 := &Col{Min: 1, Max: 1, Hidden: bPtr(true)}
 	cs.Add(col0)
@@ -521,26 +522,27 @@ func (css *ColStoreSuite) TestForEach(c *C) {
 		col.Phonetic = bPtr(true)
 	})
 
-	c.Assert(col0.Phonetic, Equals, true)
-	c.Assert(col1.Phonetic, Equals, true)
-	c.Assert(col2.Phonetic, Equals, true)
-	c.Assert(col3.Phonetic, Equals, true)
-	c.Assert(col4.Phonetic, Equals, true)
+	c.Assert(*col0.Phonetic, qt.Equals, true)
+	c.Assert(*col1.Phonetic, qt.Equals, true)
+	c.Assert(*col2.Phonetic, qt.Equals, true)
+	c.Assert(*col3.Phonetic, qt.Equals, true)
+	c.Assert(*col4.Phonetic, qt.Equals, true)
 }
 
-func (css *ColStoreSuite) TestGetOrMakeColsForRange(c *C) {
+func TestGetOrMakeColsForRange(t *testing.T) {
+	c := qt.New(t)
 	assertCols := func(min, max int, initalCols, expectedCols []*Col) {
 		cs := &ColStore{}
 		for _, col := range initalCols {
 			cs.Add(col)
 		}
 		result := cs.getOrMakeColsForRange(cs.Root, min, max)
-		c.Assert(result, HasLen, len(expectedCols))
+		c.Assert(result, qt.HasLen, len(expectedCols))
 		for i := 0; i < len(expectedCols); i++ {
 			got := result[i]
 			expected := expectedCols[i]
-			c.Assert(got.Min, Equals, expected.Min)
-			c.Assert(got.Max, Equals, expected.Max)
+			c.Assert(got.Min, qt.Equals, expected.Min)
+			c.Assert(got.Max, qt.Equals, expected.Max)
 		}
 	}
 

--- a/date_test.go
+++ b/date_test.go
@@ -1,78 +1,81 @@
 package xlsx
 
 import (
-	. "gopkg.in/check.v1"
+	"testing"
 	"time"
+
+	qt "github.com/frankban/quicktest"
 )
 
-type DateSuite struct{}
-
-var _ = Suite(&DateSuite{})
-
-func (d *DateSuite) TestFractionOfADay(c *C) {
+func TestFractionOfADay(t *testing.T) {
+	c := qt.New(t)
 	var h, m, s, n int
 	h, m, s, n = fractionOfADay(0)
-	c.Assert(h, Equals, 0)
-	c.Assert(m, Equals, 0)
-	c.Assert(s, Equals, 0)
-	c.Assert(n, Equals, 0)
+	c.Assert(h, qt.Equals, 0)
+	c.Assert(m, qt.Equals, 0)
+	c.Assert(s, qt.Equals, 0)
+	c.Assert(n, qt.Equals, 0)
 	h, m, s, n = fractionOfADay(1.0 / 24.0)
-	c.Assert(h, Equals, 1)
-	c.Assert(m, Equals, 0)
-	c.Assert(s, Equals, 0)
-	c.Assert(n, Equals, 0)
+	c.Assert(h, qt.Equals, 1)
+	c.Assert(m, qt.Equals, 0)
+	c.Assert(s, qt.Equals, 0)
+	c.Assert(n, qt.Equals, 0)
 }
 
-func (d *DateSuite) TestJulianDateToGregorianTime(c *C) {
+func TestJulianDateToGregorianTime(t *testing.T) {
+	c := qt.New(t)
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.0),
-		Equals, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.5),
-		Equals, time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC))
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.245),
-		Equals, time.Date(2000, 1, 1, 5, 52, 48, 0, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 5, 52, 48, 0, time.UTC))
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.2456),
-		Equals, time.Date(2000, 1, 1, 5, 53, 39, 840000000, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 5, 53, 39, 840000000, time.UTC))
 	/* test rounding: 0.24560789123*24*3600 = 21220.521802272 */
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.24560789123),
-		Equals, time.Date(2000, 1, 1, 5, 53, 40, 521802000, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 5, 53, 40, 521802000, time.UTC))
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.1),
-		Equals, time.Date(2000, 1, 1, 2, 24, 00, 0, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 2, 24, 00, 0, time.UTC))
 	c.Assert(julianDateToGregorianTime(2400000.5, 51544.75),
-		Equals, time.Date(2000, 1, 1, 18, 0, 0, 0, time.UTC))
+		qt.Equals, time.Date(2000, 1, 1, 18, 0, 0, 0, time.UTC))
 }
 
-func (d *DateSuite) TestTimeFromExcelTime(c *C) {
+func TestTimeFromExcelTime(t *testing.T) {
+	c := qt.New(t)
 	date := TimeFromExcelTime(0, false)
-	c.Assert(date, Equals, time.Date(1899, 12, 30, 0, 0, 0, 0, time.UTC))
+	c.Assert(date, qt.Equals, time.Date(1899, 12, 30, 0, 0, 0, 0, time.UTC))
 	date = TimeFromExcelTime(60, false)
-	c.Assert(date, Equals, time.Date(1900, 2, 28, 0, 0, 0, 0, time.UTC))
+	c.Assert(date, qt.Equals, time.Date(1900, 2, 28, 0, 0, 0, 0, time.UTC))
 	date = TimeFromExcelTime(61, false)
-	c.Assert(date, Equals, time.Date(1900, 3, 1, 0, 0, 0, 0, time.UTC))
+	c.Assert(date, qt.Equals, time.Date(1900, 3, 1, 0, 0, 0, 0, time.UTC))
 	date = TimeFromExcelTime(41275.0, false)
-	c.Assert(date, Equals, time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC))
+	c.Assert(date, qt.Equals, time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC))
 	date = TimeFromExcelTime(401769, false)
-	c.Assert(date, Equals, time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
+	c.Assert(date, qt.Equals, time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
 }
 
-func (d *DateSuite) TestTimeFromExcelTimeWithFractionalPart(c *C) {
+func TestTimeFromExcelTimeWithFractionalPart(t *testing.T) {
+	c := qt.New(t)
 	date := TimeFromExcelTime(0.114583333333333, false)
-	c.Assert(date.Round(time.Second), Equals, time.Date(1899, 12, 30, 2, 45, 0, 0, time.UTC))
+	c.Assert(date.Round(time.Second), qt.Equals, time.Date(1899, 12, 30, 2, 45, 0, 0, time.UTC))
 
 	date = TimeFromExcelTime(60.1145833333333, false)
-	c.Assert(date.Round(time.Second), Equals, time.Date(1900, 2, 28, 2, 45, 0, 0, time.UTC))
+	c.Assert(date.Round(time.Second), qt.Equals, time.Date(1900, 2, 28, 2, 45, 0, 0, time.UTC))
 
 	date = TimeFromExcelTime(61.3986111111111, false)
-	c.Assert(date.Round(time.Second), Equals, time.Date(1900, 3, 1, 9, 34, 0, 0, time.UTC))
+	c.Assert(date.Round(time.Second), qt.Equals, time.Date(1900, 3, 1, 9, 34, 0, 0, time.UTC))
 
 	date = TimeFromExcelTime(37947.75, false)
-	c.Assert(date.Round(time.Second), Equals, time.Date(2003, 11, 22, 18, 0, 0, 0, time.UTC))
+	c.Assert(date.Round(time.Second), qt.Equals, time.Date(2003, 11, 22, 18, 0, 0, 0, time.UTC))
 
 	date = TimeFromExcelTime(41275.1145833333, false)
-	c.Assert(date.Round(time.Second), Equals, time.Date(2013, 1, 1, 2, 45, 0, 0, time.UTC))
+	c.Assert(date.Round(time.Second), qt.Equals, time.Date(2013, 1, 1, 2, 45, 0, 0, time.UTC))
 }
 
-func (d *DateSuite) TestTimeFromExcelTimeWith1904Offest(c *C) {
+func TestTimeFromExcelTimeWith1904Offest(t *testing.T) {
+	c := qt.New(t)
 	date1904Offset := TimeFromExcelTime(39813.0, true)
-	c.Assert(date1904Offset, Equals, time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC))
+	c.Assert(date1904Offset, qt.Equals, time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC))
 
 }

--- a/reftable_test.go
+++ b/reftable_test.go
@@ -3,119 +3,123 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 )
 
 type RefTableSuite struct {
 	SharedStringsXML *bytes.Buffer
 }
 
-var _ = Suite(&RefTableSuite{})
-
-func (s *RefTableSuite) SetUpTest(c *C) {
-	s.SharedStringsXML = bytes.NewBufferString(
-		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-             count="4"
-             uniqueCount="4">
-          <si>
-            <t>Foo</t>
-          </si>
-          <si>
-            <t>Bar</t>
-          </si>
-          <si>
-            <t xml:space="preserve">Baz 
+var reftabletest_sharedStringsXMLStr = (
+	`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+	<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+		 count="4"
+		 uniqueCount="4">
+	  <si>
+		<t>Foo</t>
+	  </si>
+	  <si>
+		<t>Bar</t>
+	  </si>
+	  <si>
+		<t xml:space="preserve">Baz 
 </t>
-          </si>
-          <si>
-            <t>Quuk</t>
-          </si>
-          <si>
-            <r>
-              <rPr>
-                <sz val="11.5"/>
-                <rFont val="Font1"/>
-              </rPr>
-              <t>Text1</t>
-            </r>
-            <r>
-              <rPr>
-                <sz val="12.5"/>
-                <rFont val="Font2"/>
-              </rPr>
-              <t>Text2</t>
-            </r>
-          </si>
-		  </sst>`)
-}
+	  </si>
+	  <si>
+		<t>Quuk</t>
+	  </si>
+	  <si>
+		<r>
+		  <rPr>
+			<sz val="11.5"/>
+			<rFont val="Font1"/>
+		  </rPr>
+		  <t>Text1</t>
+		</r>
+		<r>
+		  <rPr>
+			<sz val="12.5"/>
+			<rFont val="Font2"/>
+		  </rPr>
+		  <t>Text2</t>
+		</r>
+	  </si>
+	  </sst>`)
 
 // We can add a new string to the RefTable
-func (s *RefTableSuite) TestRefTableAddString(c *C) {
+func TestRefTableAddString(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	index := refTable.AddString("Foo")
-	c.Assert(index, Equals, 0)
+	c.Assert(index, qt.Equals, 0)
 	p, r := refTable.ResolveSharedString(0)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 }
 
-func (s *RefTableSuite) TestCreateNewSharedStringRefTable(c *C) {
+func TestCreateNewSharedStringRefTable(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.AddString("Foo")
 	refTable.AddString("Bar")
 	p, r := refTable.ResolveSharedString(0)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 	p, r = refTable.ResolveSharedString(1)
-	c.Assert(p, Equals, "Bar")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Bar")
+	c.Assert(r, qt.IsNil)
 }
 
 // Test we can correctly convert a xlsxSST into a reference table
 // using xlsx.MakeSharedStringRefTable().
-func (s *RefTableSuite) TestMakeSharedStringRefTable(c *C) {
+func TestMakeSharedStringRefTable(t *testing.T) {
+	c := qt.New(t)
 	sst := new(xlsxSST)
-	err := xml.NewDecoder(s.SharedStringsXML).Decode(sst)
-	c.Assert(err, IsNil)
+	sharedStringsXML := bytes.NewBufferString(reftabletest_sharedStringsXMLStr)
+	err := xml.NewDecoder(sharedStringsXML).Decode(sst)
+	c.Assert(err, qt.IsNil)
 	reftable := MakeSharedStringRefTable(sst)
-	c.Assert(reftable.Length(), Equals, 5)
+	c.Assert(reftable.Length(), qt.Equals, 5)
 	p, r := reftable.ResolveSharedString(0)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 	p, r = reftable.ResolveSharedString(1)
-	c.Assert(p, Equals, "Bar")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Bar")
+	c.Assert(r, qt.IsNil)
 	p, r = reftable.ResolveSharedString(2)
-	c.Assert(p, Equals, "Baz \n")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Baz \n")
+	c.Assert(r, qt.IsNil)
 	p, r = reftable.ResolveSharedString(3)
-	c.Assert(p, Equals, "Quuk")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Quuk")
+	c.Assert(r, qt.IsNil)
 	p, r = reftable.ResolveSharedString(4)
-	c.Assert(p, Equals, "")
-	c.Assert(r, HasLen, 2)
-	c.Assert(r[0].Font.Size, Equals, 11.5)
-	c.Assert(r[0].Font.Name, Equals, "Font1")
-	c.Assert(r[1].Font.Size, Equals, 12.5)
-	c.Assert(r[1].Font.Name, Equals, "Font2")
+	c.Assert(p, qt.Equals, "")
+	c.Assert(r, qt.HasLen, 2)
+	c.Assert(r[0].Font.Size, qt.Equals, 11.5)
+	c.Assert(r[0].Font.Name, qt.Equals, "Font1")
+	c.Assert(r[1].Font.Size, qt.Equals, 12.5)
+	c.Assert(r[1].Font.Name, qt.Equals, "Font2")
 }
 
 // Test we can correctly resolve a numeric reference in the reference
 // table to a string value using RefTable.ResolveSharedString().
-func (s *RefTableSuite) TestResolveSharedString(c *C) {
+func TestResolveSharedString(t *testing.T) {
+	c := qt.New(t)
 	sst := new(xlsxSST)
-	err := xml.NewDecoder(s.SharedStringsXML).Decode(sst)
-	c.Assert(err, IsNil)
+	sharedStringsXML := bytes.NewBufferString(reftabletest_sharedStringsXMLStr)
+	err := xml.NewDecoder(sharedStringsXML).Decode(sst)
+	c.Assert(err, qt.IsNil)
 	reftable := MakeSharedStringRefTable(sst)
 	p, r := reftable.ResolveSharedString(0)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 }
 
 // Test we can correctly create the xlsx.xlsxSST struct from a RefTable
-func (s *RefTableSuite) TestMakeXLSXSST(c *C) {
+func TestMakeXLSXSST(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.AddString("Foo")
 	refTable.AddString("Bar")
@@ -133,23 +137,24 @@ func (s *RefTableSuite) TestMakeXLSXSST(c *C) {
 		},
 	})
 	sst := refTable.makeXLSXSST()
-	c.Assert(sst, NotNil)
-	c.Assert(sst.Count, Equals, 3)
-	c.Assert(sst.UniqueCount, Equals, 3)
-	c.Assert(sst.SI, HasLen, 3)
+	c.Assert(sst, qt.IsNotNil)
+	c.Assert(sst.Count, qt.Equals, 3)
+	c.Assert(sst.UniqueCount, qt.Equals, 3)
+	c.Assert(sst.SI, qt.HasLen, 3)
 	si := sst.SI[0]
-	c.Assert(si.T.Text, Equals, "Foo")
-	c.Assert(si.R, IsNil)
+	c.Assert(si.T.Text, qt.Equals, "Foo")
+	c.Assert(si.R, qt.IsNil)
 	si = sst.SI[2]
-	c.Assert(si.T, IsNil)
-	c.Assert(si.R, HasLen, 2)
-	c.Assert(si.R[0].RPr.B, NotNil)
-	c.Assert(si.R[0].T.Text, Equals, "Text1")
-	c.Assert(si.R[1].RPr, IsNil)
-	c.Assert(si.R[1].T.Text, Equals, "Text2")
+	c.Assert(si.T, qt.IsNil)
+	c.Assert(si.R, qt.HasLen, 2)
+	c.Assert(si.R[0].RPr.B, qt.IsNotNil)
+	c.Assert(si.R[0].T.Text, qt.Equals, "Text1")
+	c.Assert(si.R[1].RPr, qt.IsNil)
+	c.Assert(si.R[1].T.Text, qt.Equals, "Text2")
 }
 
-func (s *RefTableSuite) TestMarshalSST(c *C) {
+func TestMarshalSST(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.AddString("Foo")
 	refTable.AddRichText([]RichTextRun{
@@ -169,44 +174,47 @@ func (s *RefTableSuite) TestMarshalSST(c *C) {
 
 	output := bytes.NewBufferString(xml.Header)
 	body, err := xml.Marshal(sst)
-	c.Assert(err, IsNil)
-	c.Assert(body, NotNil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(body, qt.IsNotNil)
 	_, err = output.Write(body)
-	c.Assert(err, IsNil)
+	c.Assert(err, qt.IsNil)
 
 	expectedXLSXSST := `<?xml version="1.0" encoding="UTF-8"?>
 <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="2" uniqueCount="2"><si><t>Foo</t></si><si><r><rPr><b></b></rPr><t>Text1</t></r><r><t>Text2</t></r></si></sst>`
-	c.Assert(output.String(), Equals, expectedXLSXSST)
+	c.Assert(output.String(), qt.Equals, expectedXLSXSST)
 }
 
-func (s *RefTableSuite) TestRefTableReadAddString(c *C) {
+func TestRefTableReadAddString(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.isWrite = false
 	index1 := refTable.AddString("Foo")
 	index2 := refTable.AddString("Foo")
-	c.Assert(index1, Equals, 0)
-	c.Assert(index2, Equals, 1)
+	c.Assert(index1, qt.Equals, 0)
+	c.Assert(index2, qt.Equals, 1)
 	p, r := refTable.ResolveSharedString(0)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 	p, r = refTable.ResolveSharedString(1)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 }
 
-func (s *RefTableSuite) TestRefTableWriteAddString(c *C) {
+func TestRefTableWriteAddString(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.isWrite = true
 	index1 := refTable.AddString("Foo")
 	index2 := refTable.AddString("Foo")
-	c.Assert(index1, Equals, 0)
-	c.Assert(index2, Equals, 0)
+	c.Assert(index1, qt.Equals, 0)
+	c.Assert(index2, qt.Equals, 0)
 	p, r := refTable.ResolveSharedString(0)
-	c.Assert(p, Equals, "Foo")
-	c.Assert(r, IsNil)
+	c.Assert(p, qt.Equals, "Foo")
+	c.Assert(r, qt.IsNil)
 }
 
-func (s *RefTableSuite) TestRefTableReadAddRichText(c *C) {
+func TestRefTableReadAddRichText(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.isWrite = false
 	index1 := refTable.AddRichText([]RichTextRun{
@@ -230,21 +238,22 @@ func (s *RefTableSuite) TestRefTableReadAddRichText(c *C) {
 		},
 	})
 
-	c.Assert(index1, Equals, 0)
-	c.Assert(index2, Equals, 1)
+	c.Assert(index1, qt.Equals, 0)
+	c.Assert(index2, qt.Equals, 1)
 	p, r := refTable.ResolveSharedString(0)
-	c.Assert(p, Equals, "")
-	c.Assert(r, HasLen, 1)
-	c.Assert(r[0].Font.Bold, NotNil)
-	c.Assert(r[0].Text, Equals, "Text1")
+	c.Assert(p, qt.Equals, "")
+	c.Assert(r, qt.HasLen, 1)
+	c.Assert(r[0].Font.Bold, qt.IsNotNil)
+	c.Assert(r[0].Text, qt.Equals, "Text1")
 	p, r = refTable.ResolveSharedString(1)
-	c.Assert(p, Equals, "")
-	c.Assert(r, HasLen, 1)
-	c.Assert(r[0].Font.Bold, NotNil)
-	c.Assert(r[0].Text, Equals, "Text1")
+	c.Assert(p, qt.Equals, "")
+	c.Assert(r, qt.HasLen, 1)
+	c.Assert(r[0].Font.Bold, qt.IsNotNil)
+	c.Assert(r[0].Text, qt.Equals, "Text1")
 }
 
-func (s *RefTableSuite) TestRefTableWriteAddRichText(c *C) {
+func TestRefTableWriteAddRichText(t *testing.T) {
+	c := qt.New(t)
 	refTable := NewSharedStringRefTable()
 	refTable.isWrite = true
 	index1 := refTable.AddRichText([]RichTextRun{
@@ -268,11 +277,11 @@ func (s *RefTableSuite) TestRefTableWriteAddRichText(c *C) {
 		},
 	})
 
-	c.Assert(index1, Equals, 0)
-	c.Assert(index2, Equals, 0)
+	c.Assert(index1, qt.Equals, 0)
+	c.Assert(index2, qt.Equals, 0)
 	p, r := refTable.ResolveSharedString(0)
-	c.Assert(p, Equals, "")
-	c.Assert(r, HasLen, 1)
-	c.Assert(r[0].Font.Bold, NotNil)
-	c.Assert(r[0].Text, Equals, "Text1")
+	c.Assert(p, qt.Equals, "")
+	c.Assert(r, qt.HasLen, 1)
+	c.Assert(r[0].Font.Bold, qt.IsNotNil)
+	c.Assert(r[0].Text, qt.Equals, "Text1")
 }

--- a/richtext_test.go
+++ b/richtext_test.go
@@ -1,24 +1,25 @@
 package xlsx
 
 import (
-	. "gopkg.in/check.v1"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
-type RichTextSuite struct{}
-
-var _ = Suite(&RichTextSuite{})
-
-func (s *RichTextSuite) TestNewRichTextColorFromARGB(c *C) {
+func TestNewRichTextColorFromARGB(t *testing.T) {
+	c := qt.New(t)
 	rtColor := NewRichTextColorFromARGB(127, 128, 129, 130)
-	c.Assert(rtColor.coreColor.RGB, Equals, "7F808182")
+	c.Assert(rtColor.coreColor.RGB, qt.Equals, "7F808182")
 }
 
-func (s *RichTextSuite) TestNewRichTextColorFromThemeColor(c *C) {
+func TestNewRichTextColorFromThemeColor(t *testing.T) {
+	c := qt.New(t)
 	rtColor := NewRichTextColorFromThemeColor(123)
-	c.Assert(*rtColor.coreColor.Theme, Equals, 123)
+	c.Assert(*rtColor.coreColor.Theme, qt.Equals, 123)
 }
 
-func (s *RichTextSuite) TestRichTextRunEquals(c *C) {
+func TestRichTextRunEquals(t *testing.T) {
+	c := qt.New(t)
 	r1color := 1
 	r1 := &RichTextRun{
 		Font: &RichTextFont{
@@ -85,24 +86,25 @@ func (s *RichTextSuite) TestRichTextRunEquals(c *C) {
 
 	var r7 *RichTextRun = nil
 
-	c.Assert(r1.Equals(r2), Equals, true)
-	c.Assert(r1.Equals(r3), Equals, false)
-	c.Assert(r1.Equals(r4), Equals, false)
-	c.Assert(r1.Equals(r5), Equals, false)
-	c.Assert(r1.Equals(r6), Equals, false)
-	c.Assert(r1.Equals(r7), Equals, false)
+	c.Assert(r1.Equals(r2), qt.Equals, true)
+	c.Assert(r1.Equals(r3), qt.Equals, false)
+	c.Assert(r1.Equals(r4), qt.Equals, false)
+	c.Assert(r1.Equals(r5), qt.Equals, false)
+	c.Assert(r1.Equals(r6), qt.Equals, false)
+	c.Assert(r1.Equals(r7), qt.Equals, false)
 
-	c.Assert(r2.Equals(r1), Equals, true)
-	c.Assert(r3.Equals(r1), Equals, false)
-	c.Assert(r4.Equals(r1), Equals, false)
-	c.Assert(r5.Equals(r1), Equals, false)
-	c.Assert(r6.Equals(r1), Equals, false)
-	c.Assert(r7.Equals(r1), Equals, false)
+	c.Assert(r2.Equals(r1), qt.Equals, true)
+	c.Assert(r3.Equals(r1), qt.Equals, false)
+	c.Assert(r4.Equals(r1), qt.Equals, false)
+	c.Assert(r5.Equals(r1), qt.Equals, false)
+	c.Assert(r6.Equals(r1), qt.Equals, false)
+	c.Assert(r7.Equals(r1), qt.Equals, false)
 
-	c.Assert(r7.Equals(nil), Equals, true)
+	c.Assert(r7.Equals(nil), qt.Equals, true)
 }
 
-func (s *RichTextSuite) TestRichTextToXml(c *C) {
+func TestRichTextToXml(t *testing.T) {
+	c := qt.New(t)
 	rtr := []RichTextRun{
 		{
 			Font: &RichTextFont{
@@ -145,86 +147,87 @@ func (s *RichTextSuite) TestRichTextToXml(c *C) {
 	}
 
 	xmlr := richTextToXml(rtr)
-	c.Assert(xmlr, HasLen, 5)
+	c.Assert(xmlr, qt.HasLen, 5)
 
 	r := xmlr[0]
-	c.Assert(r.RPr.RFont.Val, Equals, "Font")
-	c.Assert(r.RPr.Charset.Val, Equals, int(RichTextCharsetHebrew))
-	c.Assert(r.RPr.Family.Val, Equals, int(RichTextFontFamilyScript))
-	c.Assert(r.RPr.B.Val, Equals, true)
-	c.Assert(r.RPr.I.Val, Equals, false)
-	c.Assert(r.RPr.Strike.Val, Equals, false)
-	c.Assert(r.RPr.Outline.Val, Equals, false)
-	c.Assert(r.RPr.Shadow.Val, Equals, false)
-	c.Assert(r.RPr.Condense.Val, Equals, false)
-	c.Assert(r.RPr.Extend.Val, Equals, false)
-	c.Assert(r.RPr.Color.RGB, Equals, "DEADBEEF")
-	c.Assert(r.RPr.Sz.Val, Equals, 12.345)
-	c.Assert(r.RPr.U.Val, Equals, string(RichTextUnderlineSingle))
-	c.Assert(r.RPr.VertAlign.Val, Equals, string(RichTextVertAlignSuperscript))
-	c.Assert(r.RPr.Scheme, IsNil)
-	c.Assert(r.T.Text, Equals, "Bold")
+	c.Assert(r.RPr.RFont.Val, qt.Equals, "Font")
+	c.Assert(r.RPr.Charset.Val, qt.Equals, int(RichTextCharsetHebrew))
+	c.Assert(r.RPr.Family.Val, qt.Equals, int(RichTextFontFamilyScript))
+	c.Assert(r.RPr.B.Val, qt.Equals, true)
+	c.Assert(r.RPr.I.Val, qt.Equals, false)
+	c.Assert(r.RPr.Strike.Val, qt.Equals, false)
+	c.Assert(r.RPr.Outline.Val, qt.Equals, false)
+	c.Assert(r.RPr.Shadow.Val, qt.Equals, false)
+	c.Assert(r.RPr.Condense.Val, qt.Equals, false)
+	c.Assert(r.RPr.Extend.Val, qt.Equals, false)
+	c.Assert(r.RPr.Color.RGB, qt.Equals, "DEADBEEF")
+	c.Assert(r.RPr.Sz.Val, qt.Equals, 12.345)
+	c.Assert(r.RPr.U.Val, qt.Equals, string(RichTextUnderlineSingle))
+	c.Assert(r.RPr.VertAlign.Val, qt.Equals, string(RichTextVertAlignSuperscript))
+	c.Assert(r.RPr.Scheme, qt.IsNil)
+	c.Assert(r.T.Text, qt.Equals, "Bold")
 
 	r = xmlr[1]
-	c.Assert(r.RPr.RFont, IsNil)
-	c.Assert(r.RPr.Charset, IsNil)
-	c.Assert(r.RPr.Family, IsNil)
-	c.Assert(r.RPr.B.Val, Equals, false)
-	c.Assert(r.RPr.I.Val, Equals, true)
-	c.Assert(r.RPr.Strike.Val, Equals, false)
-	c.Assert(r.RPr.Outline.Val, Equals, false)
-	c.Assert(r.RPr.Shadow.Val, Equals, false)
-	c.Assert(r.RPr.Condense.Val, Equals, false)
-	c.Assert(r.RPr.Extend.Val, Equals, false)
-	c.Assert(r.RPr.Color, IsNil)
-	c.Assert(r.RPr.Sz, IsNil)
-	c.Assert(r.RPr.U, IsNil)
-	c.Assert(r.RPr.VertAlign, IsNil)
-	c.Assert(r.RPr.Scheme, IsNil)
-	c.Assert(r.T.Text, Equals, "Italic")
+	c.Assert(r.RPr.RFont, qt.IsNil)
+	c.Assert(r.RPr.Charset, qt.IsNil)
+	c.Assert(r.RPr.Family, qt.IsNil)
+	c.Assert(r.RPr.B.Val, qt.Equals, false)
+	c.Assert(r.RPr.I.Val, qt.Equals, true)
+	c.Assert(r.RPr.Strike.Val, qt.Equals, false)
+	c.Assert(r.RPr.Outline.Val, qt.Equals, false)
+	c.Assert(r.RPr.Shadow.Val, qt.Equals, false)
+	c.Assert(r.RPr.Condense.Val, qt.Equals, false)
+	c.Assert(r.RPr.Extend.Val, qt.Equals, false)
+	c.Assert(r.RPr.Color, qt.IsNil)
+	c.Assert(r.RPr.Sz, qt.IsNil)
+	c.Assert(r.RPr.U, qt.IsNil)
+	c.Assert(r.RPr.VertAlign, qt.IsNil)
+	c.Assert(r.RPr.Scheme, qt.IsNil)
+	c.Assert(r.T.Text, qt.Equals, "Italic")
 
 	r = xmlr[2]
-	c.Assert(r.RPr.RFont, IsNil)
-	c.Assert(r.RPr.Charset, IsNil)
-	c.Assert(r.RPr.Family, IsNil)
-	c.Assert(r.RPr.B.Val, Equals, false)
-	c.Assert(r.RPr.I.Val, Equals, false)
-	c.Assert(r.RPr.Strike.Val, Equals, true)
-	c.Assert(r.RPr.Outline.Val, Equals, false)
-	c.Assert(r.RPr.Shadow.Val, Equals, false)
-	c.Assert(r.RPr.Condense.Val, Equals, false)
-	c.Assert(r.RPr.Extend.Val, Equals, false)
-	c.Assert(r.RPr.Color, IsNil)
-	c.Assert(r.RPr.Sz, IsNil)
-	c.Assert(r.RPr.U, IsNil)
-	c.Assert(r.RPr.VertAlign, IsNil)
-	c.Assert(r.RPr.Scheme, IsNil)
-	c.Assert(r.T.Text, Equals, "Strike")
+	c.Assert(r.RPr.RFont, qt.IsNil)
+	c.Assert(r.RPr.Charset, qt.IsNil)
+	c.Assert(r.RPr.Family, qt.IsNil)
+	c.Assert(r.RPr.B.Val, qt.Equals, false)
+	c.Assert(r.RPr.I.Val, qt.Equals, false)
+	c.Assert(r.RPr.Strike.Val, qt.Equals, true)
+	c.Assert(r.RPr.Outline.Val, qt.Equals, false)
+	c.Assert(r.RPr.Shadow.Val, qt.Equals, false)
+	c.Assert(r.RPr.Condense.Val, qt.Equals, false)
+	c.Assert(r.RPr.Extend.Val, qt.Equals, false)
+	c.Assert(r.RPr.Color, qt.IsNil)
+	c.Assert(r.RPr.Sz, qt.IsNil)
+	c.Assert(r.RPr.U, qt.IsNil)
+	c.Assert(r.RPr.VertAlign, qt.IsNil)
+	c.Assert(r.RPr.Scheme, qt.IsNil)
+	c.Assert(r.T.Text, qt.Equals, "Strike")
 
 	r = xmlr[3]
-	c.Assert(r.RPr.RFont, IsNil)
-	c.Assert(r.RPr.Charset.Val, Equals, int(RichTextCharsetANSI))
-	c.Assert(r.RPr.Family.Val, Equals, int(RichTextFontFamilyNotApplicable))
-	c.Assert(r.RPr.B.Val, Equals, false)
-	c.Assert(r.RPr.I.Val, Equals, false)
-	c.Assert(r.RPr.Strike.Val, Equals, false)
-	c.Assert(r.RPr.Outline.Val, Equals, false)
-	c.Assert(r.RPr.Shadow.Val, Equals, false)
-	c.Assert(r.RPr.Condense.Val, Equals, false)
-	c.Assert(r.RPr.Extend.Val, Equals, false)
-	c.Assert(r.RPr.Color, IsNil)
-	c.Assert(r.RPr.Sz, IsNil)
-	c.Assert(r.RPr.U, IsNil)
-	c.Assert(r.RPr.VertAlign, IsNil)
-	c.Assert(r.RPr.Scheme, IsNil)
-	c.Assert(r.T.Text, Equals, "Empty")
+	c.Assert(r.RPr.RFont, qt.IsNil)
+	c.Assert(r.RPr.Charset.Val, qt.Equals, int(RichTextCharsetANSI))
+	c.Assert(r.RPr.Family.Val, qt.Equals, int(RichTextFontFamilyNotApplicable))
+	c.Assert(r.RPr.B.Val, qt.Equals, false)
+	c.Assert(r.RPr.I.Val, qt.Equals, false)
+	c.Assert(r.RPr.Strike.Val, qt.Equals, false)
+	c.Assert(r.RPr.Outline.Val, qt.Equals, false)
+	c.Assert(r.RPr.Shadow.Val, qt.Equals, false)
+	c.Assert(r.RPr.Condense.Val, qt.Equals, false)
+	c.Assert(r.RPr.Extend.Val, qt.Equals, false)
+	c.Assert(r.RPr.Color, qt.IsNil)
+	c.Assert(r.RPr.Sz, qt.IsNil)
+	c.Assert(r.RPr.U, qt.IsNil)
+	c.Assert(r.RPr.VertAlign, qt.IsNil)
+	c.Assert(r.RPr.Scheme, qt.IsNil)
+	c.Assert(r.T.Text, qt.Equals, "Empty")
 
 	r = xmlr[4]
-	c.Assert(r.RPr, IsNil)
-	c.Assert(r.T.Text, Equals, "No Font")
+	c.Assert(r.RPr, qt.IsNil)
+	c.Assert(r.T.Text, qt.Equals, "No Font")
 }
 
-func (s *RichTextSuite) TestXmlToRichText(c *C) {
+func TestXmlToRichText(t *testing.T) {
+	c := qt.New(t)
 	xmlr := []xlsxR{
 		{
 			RPr: &xlsxRunProperties{
@@ -297,66 +300,67 @@ func (s *RichTextSuite) TestXmlToRichText(c *C) {
 	}
 
 	rtr := xmlToRichText(xmlr)
-	c.Assert(rtr, HasLen, 5)
+	c.Assert(rtr, qt.HasLen, 5)
 
 	r := rtr[0]
-	c.Assert(r.Font.Name, Equals, "Font")
-	c.Assert(r.Font.Size, Equals, 12.345)
-	c.Assert(r.Font.Family, Equals, RichTextFontFamilySwiss)
-	c.Assert(r.Font.Charset, Equals, RichTextCharsetGreek)
-	c.Assert(r.Font.Color.coreColor.RGB, Equals, "DEADBEEF")
-	c.Assert(r.Font.Bold, Equals, true)
-	c.Assert(r.Font.Italic, Equals, false)
-	c.Assert(r.Font.Strike, Equals, false)
-	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlignSuperscript)
-	c.Assert(r.Font.Underline, Equals, RichTextUnderlineDouble)
-	c.Assert(r.Text, Equals, "Bold")
+	c.Assert(r.Font.Name, qt.Equals, "Font")
+	c.Assert(r.Font.Size, qt.Equals, 12.345)
+	c.Assert(r.Font.Family, qt.Equals, RichTextFontFamilySwiss)
+	c.Assert(r.Font.Charset, qt.Equals, RichTextCharsetGreek)
+	c.Assert(r.Font.Color.coreColor.RGB, qt.Equals, "DEADBEEF")
+	c.Assert(r.Font.Bold, qt.Equals, true)
+	c.Assert(r.Font.Italic, qt.Equals, false)
+	c.Assert(r.Font.Strike, qt.Equals, false)
+	c.Assert(r.Font.VertAlign, qt.Equals, RichTextVertAlignSuperscript)
+	c.Assert(r.Font.Underline, qt.Equals, RichTextUnderlineDouble)
+	c.Assert(r.Text, qt.Equals, "Bold")
 
 	r = rtr[1]
-	c.Assert(r.Font.Name, Equals, "")
-	c.Assert(r.Font.Size, Equals, 0.0)
-	c.Assert(r.Font.Family, Equals, RichTextFontFamilyUnspecified)
-	c.Assert(r.Font.Charset, Equals, RichTextCharsetUnspecified)
-	c.Assert(r.Font.Color, IsNil)
-	c.Assert(r.Font.Bold, Equals, false)
-	c.Assert(r.Font.Italic, Equals, true)
-	c.Assert(r.Font.Strike, Equals, false)
-	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlign(""))
-	c.Assert(r.Font.Underline, Equals, RichTextUnderline(""))
-	c.Assert(r.Text, Equals, "Italic")
+	c.Assert(r.Font.Name, qt.Equals, "")
+	c.Assert(r.Font.Size, qt.Equals, 0.0)
+	c.Assert(r.Font.Family, qt.Equals, RichTextFontFamilyUnspecified)
+	c.Assert(r.Font.Charset, qt.Equals, RichTextCharsetUnspecified)
+	c.Assert(r.Font.Color, qt.IsNil)
+	c.Assert(r.Font.Bold, qt.Equals, false)
+	c.Assert(r.Font.Italic, qt.Equals, true)
+	c.Assert(r.Font.Strike, qt.Equals, false)
+	c.Assert(r.Font.VertAlign, qt.Equals, RichTextVertAlign(""))
+	c.Assert(r.Font.Underline, qt.Equals, RichTextUnderline(""))
+	c.Assert(r.Text, qt.Equals, "Italic")
 
 	r = rtr[2]
-	c.Assert(r.Font.Name, Equals, "")
-	c.Assert(r.Font.Size, Equals, 0.0)
-	c.Assert(r.Font.Family, Equals, RichTextFontFamilyUnspecified)
-	c.Assert(r.Font.Charset, Equals, RichTextCharsetUnspecified)
-	c.Assert(r.Font.Color, IsNil)
-	c.Assert(r.Font.Bold, Equals, false)
-	c.Assert(r.Font.Italic, Equals, false)
-	c.Assert(r.Font.Strike, Equals, true)
-	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlign(""))
-	c.Assert(r.Font.Underline, Equals, RichTextUnderline(""))
-	c.Assert(r.Text, Equals, "Strike")
+	c.Assert(r.Font.Name, qt.Equals, "")
+	c.Assert(r.Font.Size, qt.Equals, 0.0)
+	c.Assert(r.Font.Family, qt.Equals, RichTextFontFamilyUnspecified)
+	c.Assert(r.Font.Charset, qt.Equals, RichTextCharsetUnspecified)
+	c.Assert(r.Font.Color, qt.IsNil)
+	c.Assert(r.Font.Bold, qt.Equals, false)
+	c.Assert(r.Font.Italic, qt.Equals, false)
+	c.Assert(r.Font.Strike, qt.Equals, true)
+	c.Assert(r.Font.VertAlign, qt.Equals, RichTextVertAlign(""))
+	c.Assert(r.Font.Underline, qt.Equals, RichTextUnderline(""))
+	c.Assert(r.Text, qt.Equals, "Strike")
 
 	r = rtr[3]
-	c.Assert(r.Font.Name, Equals, "")
-	c.Assert(r.Font.Size, Equals, 0.0)
-	c.Assert(r.Font.Family, Equals, RichTextFontFamilyUnspecified)
-	c.Assert(r.Font.Charset, Equals, RichTextCharsetUnspecified)
-	c.Assert(r.Font.Color, IsNil)
-	c.Assert(r.Font.Bold, Equals, false)
-	c.Assert(r.Font.Italic, Equals, false)
-	c.Assert(r.Font.Strike, Equals, false)
-	c.Assert(r.Font.VertAlign, Equals, RichTextVertAlign(""))
-	c.Assert(r.Font.Underline, Equals, RichTextUnderline(""))
-	c.Assert(r.Text, Equals, "Empty")
+	c.Assert(r.Font.Name, qt.Equals, "")
+	c.Assert(r.Font.Size, qt.Equals, 0.0)
+	c.Assert(r.Font.Family, qt.Equals, RichTextFontFamilyUnspecified)
+	c.Assert(r.Font.Charset, qt.Equals, RichTextCharsetUnspecified)
+	c.Assert(r.Font.Color, qt.IsNil)
+	c.Assert(r.Font.Bold, qt.Equals, false)
+	c.Assert(r.Font.Italic, qt.Equals, false)
+	c.Assert(r.Font.Strike, qt.Equals, false)
+	c.Assert(r.Font.VertAlign, qt.Equals, RichTextVertAlign(""))
+	c.Assert(r.Font.Underline, qt.Equals, RichTextUnderline(""))
+	c.Assert(r.Text, qt.Equals, "Empty")
 
 	r = rtr[4]
-	c.Assert(r.Font, IsNil)
-	c.Assert(r.Text, Equals, "No Font")
+	c.Assert(r.Font, qt.IsNil)
+	c.Assert(r.Text, qt.Equals, "No Font")
 }
 
-func (s *RichTextSuite) TestRichTextToPlainText(c *C) {
+func TestRichTextToPlainText(t *testing.T) {
+	c := qt.New(t)
 	rt := []RichTextRun{
 		{
 			Font: &RichTextFont{
@@ -378,11 +382,12 @@ func (s *RichTextSuite) TestRichTextToPlainText(c *C) {
 		},
 	}
 	plainText := richTextToPlainText(rt)
-	c.Assert(plainText, Equals, "BoldItalicStrike")
+	c.Assert(plainText, qt.Equals, "BoldItalicStrike")
 }
 
-func (s *RichTextSuite) TestRichTextToPlainTextEmpty(c *C) {
+func TestRichTextToPlainTextEmpty(t *testing.T) {
+	c := qt.New(t)
 	rt := []RichTextRun{}
 	plainText := richTextToPlainText(rt)
-	c.Assert(plainText, Equals, "")
+	c.Assert(plainText, qt.Equals, "")
 }

--- a/theme_test.go
+++ b/theme_test.go
@@ -3,15 +3,13 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 )
 
-type ThemeSuite struct{}
-
-var _ = Suite(&ThemeSuite{})
-
-func (s *ThemeSuite) TestThemeColors(c *C) {
+func  TestThemeColors(t *testing.T) {
+  c := qt.New(t)
 	themeXmlBytes := bytes.NewBufferString(`
 <?xml version="1.0"?>
 <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
@@ -59,25 +57,25 @@ func (s *ThemeSuite) TestThemeColors(c *C) {
 	`)
 	var themeXml xlsxTheme
 	err := xml.NewDecoder(themeXmlBytes).Decode(&themeXml)
-	c.Assert(err, IsNil)
+	c.Assert(err, qt.IsNil)
 
 	clrSchemes := themeXml.ThemeElements.ClrScheme.Children
-	c.Assert(len(clrSchemes), Equals, 12)
+	c.Assert(len(clrSchemes), qt.Equals, 12)
 
 	dk1Scheme := clrSchemes[0]
-	c.Assert(dk1Scheme.XMLName.Local, Equals, "dk1")
-	c.Assert(dk1Scheme.SrgbClr, IsNil)
-	c.Assert(dk1Scheme.SysClr, NotNil)
-	c.Assert(dk1Scheme.SysClr.Val, Equals, "windowText")
-	c.Assert(dk1Scheme.SysClr.LastClr, Equals, "000000")
+	c.Assert(dk1Scheme.XMLName.Local, qt.Equals, "dk1")
+	c.Assert(dk1Scheme.SrgbClr, qt.IsNil)
+	c.Assert(dk1Scheme.SysClr, qt.IsNotNil)
+	c.Assert(dk1Scheme.SysClr.Val, qt.Equals, "windowText")
+	c.Assert(dk1Scheme.SysClr.LastClr, qt.Equals, "000000")
 
 	dk2Scheme := clrSchemes[2]
-	c.Assert(dk2Scheme.XMLName.Local, Equals, "dk2")
-	c.Assert(dk2Scheme.SysClr, IsNil)
-	c.Assert(dk2Scheme.SrgbClr, NotNil)
-	c.Assert(dk2Scheme.SrgbClr.Val, Equals, "1F497D")
+	c.Assert(dk2Scheme.XMLName.Local, qt.Equals, "dk2")
+	c.Assert(dk2Scheme.SysClr, qt.IsNil)
+	c.Assert(dk2Scheme.SrgbClr, qt.IsNotNil)
+	c.Assert(dk2Scheme.SrgbClr.Val, qt.Equals, "1F497D")
 
 	theme := newTheme(themeXml)
-	c.Assert(theme.themeColor(0, 0), Equals, "FFFFFFFF")
-	c.Assert(theme.themeColor(2, 0), Equals, "FFEEECE1")
+	c.Assert(theme.themeColor(0, 0), qt.Equals, "FFFFFFFF")
+	c.Assert(theme.themeColor(2, 0), qt.Equals, "FFEEECE1")
 }

--- a/xmlContentTypes_test.go
+++ b/xmlContentTypes_test.go
@@ -2,49 +2,48 @@ package xlsx
 
 import (
 	"encoding/xml"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 )
 
-type ContentTypesSuite struct{}
-
-var _ = Suite(&ContentTypesSuite{})
-
-func (l *ContentTypesSuite) TestMarshalContentTypes(c *C) {
+func TestMarshalContentTypes(t *testing.T) {
+	c := qt.New(t)
 	var types xlsxTypes = xlsxTypes{}
 	types.Overrides = make([]xlsxOverride, 1)
 	types.Overrides[0] = xlsxOverride{PartName: "/_rels/.rels", ContentType: "application/vnd.openxmlformats-package.relationships+xml"}
 	output, err := xml.Marshal(types)
 	stringOutput := xml.Header + string(output)
-	c.Assert(err, IsNil)
+	c.Assert(err, qt.IsNil)
 	expectedContentTypes := `<?xml version="1.0" encoding="UTF-8"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/_rels/.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"></Override></Types>`
-	c.Assert(stringOutput, Equals, expectedContentTypes)
+	c.Assert(stringOutput, qt.Equals, expectedContentTypes)
 }
 
-func (l *ContentTypesSuite) TestMakeDefaultContentTypes(c *C) {
+func TestMakeDefaultContentTypes(t *testing.T) {
+	c := qt.New(t)
 	var types xlsxTypes = MakeDefaultContentTypes()
-	c.Assert(len(types.Overrides), Equals, 8)
-	c.Assert(types.Overrides[0].PartName, Equals, "/_rels/.rels")
-	c.Assert(types.Overrides[0].ContentType, Equals, "application/vnd.openxmlformats-package.relationships+xml")
-	c.Assert(types.Overrides[1].PartName, Equals, "/docProps/app.xml")
-	c.Assert(types.Overrides[1].ContentType, Equals, "application/vnd.openxmlformats-officedocument.extended-properties+xml")
-	c.Assert(types.Overrides[2].PartName, Equals, "/docProps/core.xml")
-	c.Assert(types.Overrides[2].ContentType, Equals, "application/vnd.openxmlformats-package.core-properties+xml")
-	c.Assert(types.Overrides[3].PartName, Equals, "/xl/_rels/workbook.xml.rels")
-	c.Assert(types.Overrides[3].ContentType, Equals, "application/vnd.openxmlformats-package.relationships+xml")
-	c.Assert(types.Overrides[4].PartName, Equals, "/xl/sharedStrings.xml")
-	c.Assert(types.Overrides[4].ContentType, Equals, "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml")
-	c.Assert(types.Overrides[5].PartName, Equals, "/xl/styles.xml")
-	c.Assert(types.Overrides[5].ContentType, Equals, "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml")
-	c.Assert(types.Overrides[6].PartName, Equals, "/xl/workbook.xml")
-	c.Assert(types.Overrides[6].ContentType, Equals, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml")
-	c.Assert(types.Overrides[7].PartName, Equals, "/xl/theme/theme1.xml")
-	c.Assert(types.Overrides[7].ContentType, Equals, "application/vnd.openxmlformats-officedocument.theme+xml")
+	c.Assert(len(types.Overrides), qt.Equals, 8)
+	c.Assert(types.Overrides[0].PartName, qt.Equals, "/_rels/.rels")
+	c.Assert(types.Overrides[0].ContentType, qt.Equals, "application/vnd.openxmlformats-package.relationships+xml")
+	c.Assert(types.Overrides[1].PartName, qt.Equals, "/docProps/app.xml")
+	c.Assert(types.Overrides[1].ContentType, qt.Equals, "application/vnd.openxmlformats-officedocument.extended-properties+xml")
+	c.Assert(types.Overrides[2].PartName, qt.Equals, "/docProps/core.xml")
+	c.Assert(types.Overrides[2].ContentType, qt.Equals, "application/vnd.openxmlformats-package.core-properties+xml")
+	c.Assert(types.Overrides[3].PartName, qt.Equals, "/xl/_rels/workbook.xml.rels")
+	c.Assert(types.Overrides[3].ContentType, qt.Equals, "application/vnd.openxmlformats-package.relationships+xml")
+	c.Assert(types.Overrides[4].PartName, qt.Equals, "/xl/sharedStrings.xml")
+	c.Assert(types.Overrides[4].ContentType, qt.Equals, "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml")
+	c.Assert(types.Overrides[5].PartName, qt.Equals, "/xl/styles.xml")
+	c.Assert(types.Overrides[5].ContentType, qt.Equals, "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml")
+	c.Assert(types.Overrides[6].PartName, qt.Equals, "/xl/workbook.xml")
+	c.Assert(types.Overrides[6].ContentType, qt.Equals, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml")
+	c.Assert(types.Overrides[7].PartName, qt.Equals, "/xl/theme/theme1.xml")
+	c.Assert(types.Overrides[7].ContentType, qt.Equals, "application/vnd.openxmlformats-officedocument.theme+xml")
 
-	c.Assert(types.Defaults[0].Extension, Equals, "rels")
-	c.Assert(types.Defaults[0].ContentType, Equals, "application/vnd.openxmlformats-package.relationships+xml")
-	c.Assert(types.Defaults[1].Extension, Equals, "xml")
-	c.Assert(types.Defaults[1].ContentType, Equals, "application/xml")
+	c.Assert(types.Defaults[0].Extension, qt.Equals, "rels")
+	c.Assert(types.Defaults[0].ContentType, qt.Equals, "application/vnd.openxmlformats-package.relationships+xml")
+	c.Assert(types.Defaults[1].Extension, qt.Equals, "xml")
+	c.Assert(types.Defaults[1].ContentType, qt.Equals, "application/xml")
 
 }

--- a/xmlSharedStrings_test.go
+++ b/xmlSharedStrings_test.go
@@ -3,139 +3,133 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 )
 
-type SharedStringsSuite struct {
-	SharedStringsXML *bytes.Buffer
-}
-
-var _ = Suite(&SharedStringsSuite{})
-
-func (s *SharedStringsSuite) SetUpTest(c *C) {
-	s.SharedStringsXML = bytes.NewBufferString(
-		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-             count="5"
-             uniqueCount="5">
-          <si>
-            <t>Foo</t>
-          </si>
-          <si>
-            <t>Bar</t>
-          </si>
-          <si>
-            <t xml:space="preserve">Baz </t>
-          </si>
-          <si>
-            <t>Quuk</t>
-          </si>
-          <si>
-			<r>
-				<t>Normal</t>
-			</r>
-			<r>
-				<rPr>
-				</rPr>
-				<t>Normal2</t>
-			</r>
-			<r>
-				<rPr>
-					<b val="true"/>
-					<i val="false"/>
-					<strike/>
-					<condense val="1"/>
-					<extend val="0"/>
-				</rPr>
-				<t>Bools</t>
-			</r>
-			<r>
-				<rPr>
-					<sz val="13.5"/><color theme="1"/><rFont val="FontZ"/><family val="2"/><charset val="128"/><scheme val="minor"/>
-				</rPr>
-				<t>Font Spec</t>
-			</r>
-			<r>
-				<rPr>
-					<u val="single"/>
-					<vertAlign val="superscript"/>
-				</rPr>
-				<t>Misc</t>
-			</r>
-          </si>
-        </sst>`)
-}
+const xmlSharedStringsTest_sharedStringsXMLStr = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+	 count="5"
+	 uniqueCount="5">
+  <si>
+	<t>Foo</t>
+  </si>
+  <si>
+	<t>Bar</t>
+  </si>
+  <si>
+	<t xml:space="preserve">Baz </t>
+  </si>
+  <si>
+	<t>Quuk</t>
+  </si>
+  <si>
+	<r>
+		<t>Normal</t>
+	</r>
+	<r>
+		<rPr>
+		</rPr>
+		<t>Normal2</t>
+	</r>
+	<r>
+		<rPr>
+			<b val="true"/>
+			<i val="false"/>
+			<strike/>
+			<condense val="1"/>
+			<extend val="0"/>
+		</rPr>
+		<t>Bools</t>
+	</r>
+	<r>
+		<rPr>
+			<sz val="13.5"/><color theme="1"/><rFont val="FontZ"/><family val="2"/><charset val="128"/><scheme val="minor"/>
+		</rPr>
+		<t>Font Spec</t>
+	</r>
+	<r>
+		<rPr>
+			<u val="single"/>
+			<vertAlign val="superscript"/>
+		</rPr>
+		<t>Misc</t>
+	</r>
+  </si>
+</sst>`
 
 // Test we can correctly unmarshal an the sharedstrings.xml file into
 // an xlsx.xlsxSST struct and it's associated children.
-func (s *SharedStringsSuite) TestUnmarshallSharedStrings(c *C) {
+func TestUnmarshallSharedStrings(t *testing.T) {
+	c := qt.New(t)
 	sst := new(xlsxSST)
-	err := xml.NewDecoder(s.SharedStringsXML).Decode(sst)
-	c.Assert(err, IsNil)
-	c.Assert(sst.Count, Equals, 5)
-	c.Assert(sst.UniqueCount, Equals, 5)
-	c.Assert(sst.SI, HasLen, 5)
+	err := xml.NewDecoder(bytes.NewBufferString(xmlSharedStringsTest_sharedStringsXMLStr)).Decode(sst)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sst.Count, qt.Equals, 5)
+	c.Assert(sst.UniqueCount, qt.Equals, 5)
+	c.Assert(sst.SI, qt.HasLen, 5)
 
 	si := sst.SI[0]
-	c.Assert(si.T.Text, Equals, "Foo")
-	c.Assert(si.R, IsNil)
+	c.Assert(si.T.Text, qt.Equals, "Foo")
+	c.Assert(si.R, qt.IsNil)
 	si = sst.SI[1]
-	c.Assert(si.T.Text, Equals, "Bar")
-	c.Assert(si.R, IsNil)
+	c.Assert(si.T.Text, qt.Equals, "Bar")
+	c.Assert(si.R, qt.IsNil)
 	si = sst.SI[2]
-	c.Assert(si.T.Text, Equals, "Baz ")
-	c.Assert(si.R, IsNil)
+	c.Assert(si.T.Text, qt.Equals, "Baz ")
+	c.Assert(si.R, qt.IsNil)
 	si = sst.SI[3]
-	c.Assert(si.T.Text, Equals, "Quuk")
-	c.Assert(si.R, IsNil)
+	c.Assert(si.T.Text, qt.Equals, "Quuk")
+	c.Assert(si.R, qt.IsNil)
 	si = sst.SI[4]
-	c.Assert(si.T, IsNil)
-	c.Assert(len(si.R), Equals, 5)
+	c.Assert(si.T, qt.IsNil)
+	c.Assert(len(si.R), qt.Equals, 5)
 	r := si.R[0]
-	c.Assert(r.T.Text, Equals, "Normal")
-	c.Assert(r.RPr, IsNil)
+	c.Assert(r.T.Text, qt.Equals, "Normal")
+	c.Assert(r.RPr, qt.IsNil)
 	r = si.R[1]
-	c.Assert(r.T.Text, Equals, "Normal2")
-	c.Assert(r.RPr.RFont, IsNil)
-	c.Assert(r.RPr.Sz, IsNil)
-	c.Assert(r.RPr.Color, IsNil)
-	c.Assert(r.RPr.Family, IsNil)
-	c.Assert(r.RPr.Charset, IsNil)
-	c.Assert(r.RPr.Scheme, IsNil)
-	c.Assert(r.RPr.B.Val, Equals, false)
-	c.Assert(r.RPr.I.Val, Equals, false)
-	c.Assert(r.RPr.Strike.Val, Equals, false)
-	c.Assert(r.RPr.Outline.Val, Equals, false)
-	c.Assert(r.RPr.Shadow.Val, Equals, false)
-	c.Assert(r.RPr.Condense.Val, Equals, false)
-	c.Assert(r.RPr.Extend.Val, Equals, false)
-	c.Assert(r.RPr.U, IsNil)
-	c.Assert(r.RPr.VertAlign, IsNil)
+	c.Assert(r.T.Text, qt.Equals, "Normal2")
+	c.Assert(r.RPr.RFont, qt.IsNil)
+	c.Assert(r.RPr.Sz, qt.IsNil)
+	c.Assert(r.RPr.Color, qt.IsNil)
+	c.Assert(r.RPr.Family, qt.IsNil)
+	c.Assert(r.RPr.Charset, qt.IsNil)
+	c.Assert(r.RPr.Scheme, qt.IsNil)
+	c.Assert(r.RPr.B.Val, qt.Equals, false)
+	c.Assert(r.RPr.I.Val, qt.Equals, false)
+	c.Assert(r.RPr.Strike.Val, qt.Equals, false)
+	c.Assert(r.RPr.Outline.Val, qt.Equals, false)
+	c.Assert(r.RPr.Shadow.Val, qt.Equals, false)
+	c.Assert(r.RPr.Condense.Val, qt.Equals, false)
+	c.Assert(r.RPr.Extend.Val, qt.Equals, false)
+	c.Assert(r.RPr.U, qt.IsNil)
+	c.Assert(r.RPr.VertAlign, qt.IsNil)
 	r = si.R[2]
-	c.Assert(r.T.Text, Equals, "Bools")
-	c.Assert(r.RPr.RFont, IsNil)
-	c.Assert(r.RPr.B.Val, Equals, true)
-	c.Assert(r.RPr.I.Val, Equals, false)
-	c.Assert(r.RPr.Strike.Val, Equals, true)
-	c.Assert(r.RPr.Condense.Val, Equals, true)
-	c.Assert(r.RPr.Extend.Val, Equals, false)
+	c.Assert(r.T.Text, qt.Equals, "Bools")
+	c.Assert(r.RPr.RFont, qt.IsNil)
+	c.Assert(r.RPr.B.Val, qt.Equals, true)
+	c.Assert(r.RPr.I.Val, qt.Equals, false)
+	c.Assert(r.RPr.Strike.Val, qt.Equals, true)
+	c.Assert(r.RPr.Condense.Val, qt.Equals, true)
+	c.Assert(r.RPr.Extend.Val, qt.Equals, false)
 	r = si.R[3]
-	c.Assert(r.T.Text, Equals, "Font Spec")
-	c.Assert(r.RPr.RFont.Val, Equals, "FontZ")
-	c.Assert(r.RPr.Sz.Val, Equals, 13.5)
-	c.Assert(*r.RPr.Color.Theme, Equals, 1)
-	c.Assert(r.RPr.Family.Val, Equals, 2)
-	c.Assert(r.RPr.Charset.Val, Equals, 128)
-	c.Assert(r.RPr.Scheme.Val, Equals, "minor")
+	c.Assert(r.T.Text, qt.Equals, "Font Spec")
+	c.Assert(r.RPr.RFont.Val, qt.Equals, "FontZ")
+	c.Assert(r.RPr.Sz.Val, qt.Equals, 13.5)
+	c.Assert(*r.RPr.Color.Theme, qt.Equals, 1)
+	c.Assert(r.RPr.Family.Val, qt.Equals, 2)
+	c.Assert(r.RPr.Charset.Val, qt.Equals, 128)
+	c.Assert(r.RPr.Scheme.Val, qt.Equals, "minor")
 	r = si.R[4]
-	c.Assert(r.T.Text, Equals, "Misc")
-	c.Assert(r.RPr.U.Val, Equals, "single")
-	c.Assert(r.RPr.VertAlign.Val, Equals, "superscript")
+	c.Assert(r.T.Text, qt.Equals, "Misc")
+	c.Assert(r.RPr.U.Val, qt.Equals, "single")
+	c.Assert(r.RPr.VertAlign.Val, qt.Equals, "superscript")
 }
 
 // TestMarshalSI_T tests that xlsxT is marshaled as it is expected.
-func (s *SharedStringsSuite) TestMarshalSI_T(c *C) {
+func TestMarshalSI_T(t *testing.T) {
+	c := qt.New(t)
 	testMarshalSIT(c, "", "<xlsxSI><t></t></xlsxSI>")
 	testMarshalSIT(c, "a b c", "<xlsxSI><t>a b c</t></xlsxSI>")
 	testMarshalSIT(c, " abc", "<xlsxSI><t xml:space=\"preserve\"> abc</t></xlsxSI>")
@@ -145,15 +139,16 @@ func (s *SharedStringsSuite) TestMarshalSI_T(c *C) {
 	testMarshalSIT(c, "ab\nc", "<xlsxSI><t xml:space=\"preserve\">ab\nc</t></xlsxSI>")
 }
 
-func testMarshalSIT(c *C, t string, expected string) {
+func testMarshalSIT(c *qt.C, t string, expected string) {
 	si := xlsxSI{T: &xlsxT{Text: t}}
 	bytes, err := xml.Marshal(&si)
-	c.Assert(err, IsNil)
-	c.Assert(string(bytes), Equals, expected)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(bytes), qt.Equals, expected)
 }
 
 // TestMarshalSI_R tests that xlsxR is marshaled as it is expected.
-func (s *SharedStringsSuite) TestMarshalSI_R(c *C) {
+func TestMarshalSI_R(t *testing.T) {
+	c := qt.New(t)
 	testMarshalSIR(c, xlsxR{}, "<xlsxSI><r><t></t></r></xlsxSI>")
 	testMarshalSIR(c, xlsxR{T: xlsxT{Text: "a b c"}}, "<xlsxSI><r><t>a b c</t></r></xlsxSI>")
 	testMarshalSIR(c, xlsxR{T: xlsxT{Text: " abc"}}, "<xlsxSI><r><t xml:space=\"preserve\"> abc</t></r></xlsxSI>")
@@ -202,9 +197,9 @@ func (s *SharedStringsSuite) TestMarshalSI_R(c *C) {
 		"<xlsxSI><r><rPr><scheme val=\"major\"></scheme></rPr><t>a</t></r></xlsxSI>")
 }
 
-func testMarshalSIR(c *C, r xlsxR, expected string) {
+func testMarshalSIR(c *qt.C, r xlsxR, expected string) {
 	si := xlsxSI{R: []xlsxR{r}}
 	bytes, err := xml.Marshal(&si)
-	c.Assert(err, IsNil)
-	c.Assert(string(bytes), Equals, expected)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(bytes), qt.Equals, expected)
 }

--- a/xmlWorkbook_test.go
+++ b/xmlWorkbook_test.go
@@ -3,18 +3,16 @@ package xlsx
 import (
 	"bytes"
 	"encoding/xml"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 )
-
-type WorkbookSuite struct{}
-
-var _ = Suite(&WorkbookSuite{})
 
 // Test we can succesfully unmarshal the workbook.xml file from within
 // an XLSX file and return a xlsxWorkbook struct (and associated
 // children).
-func (w *WorkbookSuite) TestUnmarshallWorkbookXML(c *C) {
+func TestUnmarshallWorkbookXML(t *testing.T) {
+	c := qt.New(t)
 	var buf = bytes.NewBufferString(
 		`<?xml version="1.0"
         encoding="UTF-8"
@@ -56,37 +54,38 @@ func (w *WorkbookSuite) TestUnmarshallWorkbookXML(c *C) {
 	var workbook *xlsxWorkbook
 	workbook = new(xlsxWorkbook)
 	err := xml.NewDecoder(buf).Decode(workbook)
-	c.Assert(err, IsNil)
-	c.Assert(workbook.FileVersion.AppName, Equals, "xl")
-	c.Assert(workbook.FileVersion.LastEdited, Equals, "4")
-	c.Assert(workbook.FileVersion.LowestEdited, Equals, "4")
-	c.Assert(workbook.FileVersion.RupBuild, Equals, "4506")
-	c.Assert(workbook.WorkbookPr.DefaultThemeVersion, Equals, "124226")
-	c.Assert(workbook.WorkbookPr.Date1904, Equals, true)
-	c.Assert(workbook.BookViews.WorkBookView, HasLen, 1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(workbook.FileVersion.AppName, qt.Equals, "xl")
+	c.Assert(workbook.FileVersion.LastEdited, qt.Equals, "4")
+	c.Assert(workbook.FileVersion.LowestEdited, qt.Equals, "4")
+	c.Assert(workbook.FileVersion.RupBuild, qt.Equals, "4506")
+	c.Assert(workbook.WorkbookPr.DefaultThemeVersion, qt.Equals, "124226")
+	c.Assert(workbook.WorkbookPr.Date1904, qt.Equals, true)
+	c.Assert(workbook.BookViews.WorkBookView, qt.HasLen, 1)
 	workBookView := workbook.BookViews.WorkBookView[0]
-	c.Assert(workBookView.XWindow, Equals, "120")
-	c.Assert(workBookView.YWindow, Equals, "75")
-	c.Assert(workBookView.WindowWidth, Equals, 15135)
-	c.Assert(workBookView.WindowHeight, Equals, 7620)
-	c.Assert(workbook.Sheets.Sheet, HasLen, 3)
+	c.Assert(workBookView.XWindow, qt.Equals, "120")
+	c.Assert(workBookView.YWindow, qt.Equals, "75")
+	c.Assert(workBookView.WindowWidth, qt.Equals, 15135)
+	c.Assert(workBookView.WindowHeight, qt.Equals, 7620)
+	c.Assert(workbook.Sheets.Sheet, qt.HasLen, 3)
 	sheet := workbook.Sheets.Sheet[0]
-	c.Assert(sheet.Id, Equals, "rId1")
-	c.Assert(sheet.Name, Equals, "Sheet1")
-	c.Assert(sheet.SheetId, Equals, "1")
-	c.Assert(sheet.State, Equals, "visible")
-	c.Assert(workbook.DefinedNames.DefinedName, HasLen, 1)
+	c.Assert(sheet.Id, qt.Equals, "rId1")
+	c.Assert(sheet.Name, qt.Equals, "Sheet1")
+	c.Assert(sheet.SheetId, qt.Equals, "1")
+	c.Assert(sheet.State, qt.Equals, "visible")
+	c.Assert(workbook.DefinedNames.DefinedName, qt.HasLen, 1)
 	dname := workbook.DefinedNames.DefinedName[0]
-	c.Assert(dname.Data, Equals, "Sheet1!$A$1533")
-	c.Assert(dname.LocalSheetID, Equals, 0)
-	c.Assert(dname.Name, Equals, "monitors")
-	c.Assert(dname.Comment, Equals, "this is the comment")
-	c.Assert(dname.Description, Equals, "give cells a name")
-	c.Assert(workbook.CalcPr.CalcId, Equals, "125725")
+	c.Assert(dname.Data, qt.Equals, "Sheet1!$A$1533")
+	c.Assert(dname.LocalSheetID, qt.Equals, 0)
+	c.Assert(dname.Name, qt.Equals, "monitors")
+	c.Assert(dname.Comment, qt.Equals, "this is the comment")
+	c.Assert(dname.Description, qt.Equals, "give cells a name")
+	c.Assert(workbook.CalcPr.CalcId, qt.Equals, "125725")
 }
 
 // Test we can marshall a Workbook to xml
-func (w *WorkbookSuite) TestMarshallWorkbook(c *C) {
+func TestMarshallWorkbook(t *testing.T) {
+	c := qt.New(t)
 	var workbook *xlsxWorkbook
 	workbook = new(xlsxWorkbook)
 	workbook.FileVersion = xlsxFileVersion{}
@@ -100,7 +99,7 @@ func (w *WorkbookSuite) TestMarshallWorkbook(c *C) {
 	workbook.Sheets.Sheet[0] = xlsxSheet{Name: "sheet1", SheetId: "1", Id: "rId2"}
 
 	body, err := xml.Marshal(workbook)
-	c.Assert(err, IsNil)
+	c.Assert(err, qt.IsNil)
 	expectedWorkbook := `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fileVersion appName="xlsx"></fileVersion><workbookPr date1904="false"></workbookPr><workbookProtection></workbookProtection><bookViews><workbookView></workbookView></bookViews><sheets><sheet name="sheet1" sheetId="1" xmlns:relationships="http://schemas.openxmlformats.org/officeDocument/2006/relationships" relationships:id="rId2"></sheet></sheets><definedNames></definedNames><calcPr></calcPr></workbook>`
-	c.Assert(string(body), Equals, expectedWorkbook)
+	c.Assert(string(body), qt.Equals, expectedWorkbook)
 }

--- a/xmlWorksheet_test.go
+++ b/xmlWorksheet_test.go
@@ -6,16 +6,12 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	. "gopkg.in/check.v1"
 )
-
-type WorksheetSuite struct{}
-
-var _ = Suite(&WorksheetSuite{})
 
 // Test we can succesfully unmarshal the sheetN.xml files within and
 // XLSX file into an xlsxWorksheet struct (and it's related children).
-func (w *WorksheetSuite) TestUnmarshallWorksheet(c *C) {
+func TestUnmarshallWorksheet(t *testing.T) {
+	c := qt.New(t)
 	var sheetxml = bytes.NewBufferString(
 		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -132,24 +128,25 @@ func (w *WorksheetSuite) TestUnmarshallWorksheet(c *C) {
         </worksheet>`)
 	worksheet := new(xlsxWorksheet)
 	err := xml.NewDecoder(sheetxml).Decode(worksheet)
-	c.Assert(err, IsNil)
-	c.Assert(worksheet.Dimension.Ref, Equals, "A1:B2")
-	c.Assert(worksheet.SheetData.Row, HasLen, 2)
-	c.Assert(worksheet.SheetFormatPr.DefaultRowHeight, Equals, 15.0)
-	c.Assert(worksheet.SheetFormatPr.DefaultColWidth, Equals, 8.0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(worksheet.Dimension.Ref, qt.Equals, "A1:B2")
+	c.Assert(worksheet.SheetData.Row, qt.HasLen, 2)
+	c.Assert(worksheet.SheetFormatPr.DefaultRowHeight, qt.Equals, 15.0)
+	c.Assert(worksheet.SheetFormatPr.DefaultColWidth, qt.Equals, 8.0)
 	row := worksheet.SheetData.Row[0]
-	c.Assert(row.R, Equals, 1)
-	c.Assert(row.C, HasLen, 2)
+	c.Assert(row.R, qt.Equals, 1)
+	c.Assert(row.C, qt.HasLen, 2)
 	cell := row.C[0]
-	c.Assert(cell.R, Equals, "A1")
-	c.Assert(cell.T, Equals, "s")
-	c.Assert(cell.V, Equals, "0")
-	c.Assert(worksheet.AutoFilter, NotNil)
-	c.Assert(worksheet.AutoFilter.Ref, Equals, "A1:Z4")
+	c.Assert(cell.R, qt.Equals, "A1")
+	c.Assert(cell.T, qt.Equals, "s")
+	c.Assert(cell.V, qt.Equals, "0")
+	c.Assert(worksheet.AutoFilter, qt.IsNotNil)
+	c.Assert(worksheet.AutoFilter.Ref, qt.Equals, "A1:Z4")
 }
 
 // MergeCells information is correctly read from the worksheet.
-func (w *WorksheetSuite) TestUnmarshallWorksheetWithMergeCells(c *C) {
+func TestUnmarshallWorksheetWithMergeCells(t *testing.T) {
+	c := qt.New(t)
 	var sheetxml = bytes.NewBufferString(
 		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
@@ -183,11 +180,11 @@ func (w *WorksheetSuite) TestUnmarshallWorksheetWithMergeCells(c *C) {
 `)
 	worksheet := new(xlsxWorksheet)
 	err := xml.NewDecoder(sheetxml).Decode(worksheet)
-	c.Assert(err, IsNil)
-	c.Assert(worksheet.MergeCells, NotNil)
-	c.Assert(worksheet.MergeCells.Count, Equals, 1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(worksheet.MergeCells, qt.IsNotNil)
+	c.Assert(worksheet.MergeCells.Count, qt.Equals, 1)
 	mergeCell := worksheet.MergeCells.Cells[0]
-	c.Assert(mergeCell.Ref, Equals, "A1:B1")
+	c.Assert(mergeCell.Ref, qt.Equals, "A1:B1")
 }
 
 // MergeCells.getExtents returns the horizontal and vertical extent of


### PR DESCRIPTION
In my `go test -v`, some tests (like in `date_test.go`) that uses `gopkg.in/check.v1` isn't being performed, even with `check.v` flag.

As such I think it would be better to switch to `quicktest`.  This commit/PR switch all tests coded with `check.v1` to `quicktest` except those in  `fuzzy_test.go`. 

Result of the switch shows that there are more lines of report (which indicates number of tests being performed).
```
> go version
go version go1.21.1 linux/amd64
> go test -v | wc -l
1390
> git checkout switch-check-to-qt 
Switched to branch 'switch-check-to-qt'
Your branch is up to date with 'origin/switch-check-to-qt'.
> go test -v | wc -l
1464
```

Attached are test run results for tests [switched to quicktest](https://github.com/tealeg/xlsx/files/12566911/testSwithedToQt.txt) and  [the original / master branch](https://github.com/tealeg/xlsx/files/12566910/testOriginalWithCheck.txt).