### PR TITLE
allow-subsecond-settime

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -307,7 +307,7 @@ func (c *Cell) SetDateTime(t time.Time) {
 func (c *Cell) SetDateWithOptions(t time.Time, options DateTimeOptions) {
 	c.updatable()
 	_, offset := t.In(options.Location).Zone()
-	t = time.Unix(t.Unix()+int64(offset), 0)
+	t = time.Unix(t.Unix()+int64(offset), int64(t.Nanosecond()))
 	c.SetDateTimeWithFormat(TimeToExcelTime(t.In(timeLocationUTC), c.date1904), options.ExcelTimeFormat)
 	c.modified = true
 }


### PR DESCRIPTION
Currently, `cellRef.SetDateWithOptions` will truncate the supplied `time.Time` to **second** accuracy.

This allows fractional/subsecond part to be passed to Excel.