### PR TITLE
Support bool type values on Cell.SetValue()

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -396,7 +396,6 @@ func (c *Cell) SetValue(n interface{}) {
 	switch t := n.(type) {
 	case time.Time:
 		c.SetDateTime(t)
-		return
 	case int, int8, int16, int32, int64:
 		c.SetNumeric(fmt.Sprintf("%d", n))
 	case float64:
@@ -412,6 +411,8 @@ func (c *Cell) SetValue(n interface{}) {
 		c.SetString(t)
 	case []byte:
 		c.SetString(string(t))
+	case bool:
+		c.SetBool(t)
 	case nil:
 		c.SetString("")
 	default:


### PR DESCRIPTION
`Cell.SetValue(bool)` sets the cell's value to be a plain string "true"/"false", instead of the expected boolean values, displayed as "TRUE" or "FALSE" on MS Excel.
Add the missing bool type case in SetValue to call `Cell.SetBool`.