### PR TITLE
fix the issue that cannot emit MergeCells and DataValidations together

### DIFF
--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -760,14 +760,18 @@ func (worksheet *xlsxWorksheet) WriteXML(xw *xmlwriter.Writer, s *Sheet, styles 
 				if err != nil {
 					return err
 				}
-				return xw.Write(mergeCells)
+				if err := xw.Write(mergeCells); err != nil {
+					return err
+				}
 			}
 			if worksheet.DataValidations != nil {
 				dataValidation, err := emitStructAsXML(reflect.ValueOf(worksheet.DataValidations), "dataValidations", "")
 				if err != nil {
 					return err
 				}
-				return xw.Write(dataValidation)
+				if err := xw.Write(dataValidation); err != nil {
+					return err
+				}
 			}
 			return nil
 		}(),


### PR DESCRIPTION
The bug is very simple:
if `worksheet.MergeCells` is not nil and `xw.Write(mergeCells)` executed, code returned incorrectly.
So, the logic of `worksheet.DataValidations` won't be executed even it's not nil.