### PR TITLE
Fix Excel opening files with AutoFilter data

### DIFF
--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -595,7 +595,7 @@ func emitStructAsXML(v reflect.Value, name, xmlNS string) (xmlwriter.Elem, error
 				Name:  "xmlns",
 				Value: xmlNS,
 			})
-		case "SheetData", "MergeCells", "DataValidations":
+		case "SheetData", "MergeCells", "DataValidations", "AutoFilter":
 			// Skip SheetData here, we explicitly generate this in writeXML below
 			// Microsoft Excel considers a mergeCells element before a sheetData element to be
 			// an error and will fail to open the document, so we'll be back with this data
@@ -770,6 +770,15 @@ func (worksheet *xlsxWorksheet) WriteXML(xw *xmlwriter.Writer, s *Sheet, styles 
 					return err
 				}
 				if err := xw.Write(dataValidation); err != nil {
+					return err
+				}
+			}
+			if worksheet.AutoFilter != nil {
+				autoFilter, err := emitStructAsXML(reflect.ValueOf(worksheet.AutoFilter), "autoFilter", "")
+				if err != nil {
+					return err
+				}
+				if err := xw.Write(autoFilter); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Microsoft Excel is unable to open xlsx generated Excel files that contain AutoFilter data. This fix saves the autoFilter XML tag after sheetData and the Excel files work as expected.

Addresses the following issues
- https://github.com/tealeg/xlsx/issues/424
- https://github.com/tealeg/xlsx/issues/727
