### PR TITLE
fix AutoFilter not working in LibreOffice

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -965,6 +965,25 @@ func TestFile(t *testing.T) {
 		c.Assert(s.Hidden, qt.Equals, true)
 	})
 
+	csRunO(c, "TestMarshalFileWithAutoFilter", func(c *qt.C, option FileOption) {
+		var f *File
+		f = NewFile(option)
+		sheet1, _ := f.AddSheet("MySheet")
+		sheet1.AutoFilter = &AutoFilter{
+			TopLeftCell:     "A1",
+			BottomRightCell: "D",
+		}
+
+		row1 := sheet1.AddRow()
+		cell1 := row1.AddCell()
+		cell1.SetString("A cell!")
+
+		parts, err := f.MakeStreamParts()
+		c.Assert(err, qt.IsNil)
+		c.Assert(parts["xl/workbook.xml"], qt.Contains, `<definedNames><definedName name="_xlnm._FilterDatabase" localSheetId="0" hidden="true">&#39;MySheet&#39;!$A$1:$D</definedName></definedNames>`)
+		c.Assert(parts["xl/worksheets/sheet1.xml"], qt.Contains, `<autoFilter ref="A1:D"></autoFilter>`)
+	})
+
 	// We can save a File as a valid XLSX file at a given path.
 	csRunO(c, "TestSaveFileWithHyperlinks", func(c *qt.C, option FileOption) {
 		tmpPath, err := ioutil.TempDir("", "testsavefilewithhyperlinks")

--- a/xmlWorkbook.go
+++ b/xmlWorkbook.go
@@ -141,7 +141,7 @@ type xlsxDefinedName struct {
 	Help              string `xml:"help,attr,omitempty"`
 	ShortcutKey       string `xml:"shortcutKey,attr,omitempty"`
 	StatusBar         string `xml:"statusBar,attr,omitempty"`
-	LocalSheetID      int    `xml:"localSheetId,attr,omitempty"`
+	LocalSheetID      int    `xml:"localSheetId,attr"`
 	FunctionGroupID   int    `xml:"functionGroupId,attr,omitempty"`
 	Function          bool   `xml:"function,attr,omitempty"`
 	Hidden            bool   `xml:"hidden,attr,omitempty"`


### PR DESCRIPTION
AutoFilter doesn't work in LibreOffice unless a special `FilterDatabase` tag is present in the `DefinedNames` array.  See:

- https://github.com/SheetJS/sheetjs/issues/1165
- https://bugs.documentfoundation.org/show_bug.cgi?id=118592

This pull request adds the workaround that makes AutoFilter work in LibreOffice.
