### PR TITLE
fix: wrong cell & border colors using indexedColors

### DIFF
--- a/xmlStyle.go
+++ b/xmlStyle.go
@@ -237,16 +237,15 @@ func (styles *xlsxStyleSheet) populateStyleFromXf(style *Style, xf xlsxXf) {
 	style.ApplyAlignment = xf.ApplyAlignment
 
 	if xf.BorderId > -1 && xf.BorderId < styles.Borders.Count {
-		var border xlsxBorder
-		border = styles.Borders.Border[xf.BorderId]
+		border := styles.Borders.Border[xf.BorderId]
 		style.Border.Left = border.Left.Style
-		style.Border.LeftColor = border.Left.Color.RGB
+		style.Border.LeftColor = styles.argbValue(border.Left.Color)
 		style.Border.Right = border.Right.Style
-		style.Border.RightColor = border.Right.Color.RGB
+		style.Border.RightColor = styles.argbValue(border.Right.Color)
 		style.Border.Top = border.Top.Style
-		style.Border.TopColor = border.Top.Color.RGB
+		style.Border.TopColor = styles.argbValue(border.Top.Color)
 		style.Border.Bottom = border.Bottom.Style
-		style.Border.BottomColor = border.Bottom.Color.RGB
+		style.Border.BottomColor = styles.argbValue(border.Bottom.Color)
 	}
 
 	if xf.FillId > -1 && xf.FillId < styles.Fills.Count {
@@ -1150,13 +1149,15 @@ type xlsxColors struct {
 	MruColors     []xlsxColor    `xml:"mruColors>color,omitempty"`
 }
 
+// indexerdColor returns ARGB color string for the given index of the IndexedColors.
+// Indexes start from 0, see section 18.8.27 of ECMA-376 (part 1, 4th edition).
 func (c *xlsxColors) indexedColor(index int) string {
 	if c.IndexedColors != nil {
-		return c.IndexedColors[index-1].Rgb
+		return c.IndexedColors[index].Rgb
 	} else {
-		if index < 1 || index > 64 {
+		if index < 0 || index > 63 {
 			return ""
 		}
-		return xlsxIndexedColors[index-1]
+		return xlsxIndexedColors[index]
 	}
 }

--- a/xmlStyle_test.go
+++ b/xmlStyle_test.go
@@ -12,12 +12,12 @@ func TestIndexedColor(t *testing.T) {
 
 	colors := xlsxColors{}
 	c.Run("Unitialised", func(c *qt.C) {
-		c.Assert(colors.indexedColor(1), qt.Equals, "FF000000")
+		c.Assert(colors.indexedColor(0), qt.Equals, "FF000000")
 	})
 
 	c.Run("Initialised", func(c *qt.C) {
 		colors.IndexedColors = []xlsxRgbColor{{Rgb: "00FF00FF"}}
-		c.Assert(colors.indexedColor(1), qt.Equals, "00FF00FF")
+		c.Assert(colors.indexedColor(0), qt.Equals, "00FF00FF")
 	})
 }
 


### PR DESCRIPTION
Closes #815.

- Indexes of indexed colors should be zero-based.
- Indexed colors used in border styles are missing from output.

Tested with MS Excel and Numbers in macOS. Need more testing with other OS's and spreadsheet software.
