### PR TITLE
Fixed issue #809, losing rows from cellstore when moving backwards

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -30,8 +30,8 @@ type Sheet struct {
 	cellStore       CellStore
 	currentRow      *Row
 	cellStoreName   string // The first part of the key used in
-			       // the cellStore.  This name is stable,
-			       // unlike the Name, which can change
+	// the cellStore.  This name is stable,
+	// unlike the Name, which can change
 }
 
 // NewSheet constructs a Sheet with the default CellStore and returns
@@ -47,8 +47,8 @@ func NewSheetWithCellStore(name string, constructor CellStoreConstructor) (*Shee
 		return nil, fmt.Errorf("sheet name is invalid: %w", err)
 	}
 	sheet := &Sheet{
-		Name: name,
-		Cols: &ColStore{},
+		Name:          name,
+		Cols:          &ColStore{},
 		cellStoreName: name,
 	}
 	var err error
@@ -298,10 +298,15 @@ func (s *Sheet) maybeAddRow(rowCount int) {
 // Make sure we always have as many Rows as we do cells.
 func (s *Sheet) Row(idx int) (*Row, error) {
 	s.mustBeOpen()
+
 	s.maybeAddRow(idx + 1)
-	if s.currentRow != nil && idx == s.currentRow.num {
-		return s.currentRow, nil
+	if s.currentRow != nil {
+		if idx == s.currentRow.num {
+			return s.currentRow, nil
+		}
+		s.cellStore.WriteRow(s.currentRow)
 	}
+
 	r, err := s.cellStore.ReadRow(makeRowKey(s, idx), s)
 	if err != nil {
 		if _, ok := err.(*RowNotFoundError); !ok {
@@ -948,7 +953,6 @@ func handleNumFmtIdForXLSX(NumFmtId int, styles *xlsxStyleSheet) (XfId int) {
 	XfId = styles.addCellXf(xCellXf)
 	return
 }
-
 
 func IsSaneSheetName(sheetName string) error {
 	runeLength := utf8.RuneCountInString(sheetName)


### PR DESCRIPTION
Fixes #809 

There was a corner case where if you use `sheet.Cell` to open a cell in a row prior to the current row, the current row wasn't written into the cellstore and therefore evaporated if it had never been written.  