### PR TITLE
fix: new empty row index bug

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -288,7 +288,7 @@ func (s *Sheet) maybeAddRow(rowCount int) {
 		loopCnt := rowCount - s.MaxRow
 		for i := 0; i < loopCnt; i++ {
 			row := s.cellStore.MakeRow(s)
-			row.num = i
+			row.num = s.MaxRow + i
 			s.setCurrentRow(row)
 		}
 		s.MaxRow = rowCount

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -823,3 +823,25 @@ func TestTemp(t *testing.T) {
 	c.Assert(xSI.T.Text, qt.Equals, "A cell!")
 	c.Assert(xSI.R, qt.HasLen, 0)
 }
+
+func TestAddEmptyRow(t *testing.T) {
+	c := qt.New(t)
+	sourceFile, err := OpenFile("./testdocs/original.xlsx")
+	c.Assert(err, qt.IsNil)
+	sheet := sourceFile.Sheets[0]
+	c.Assert(sheet, qt.IsNotNil)
+	firstRow, err := sheet.Row(0)
+	c.Assert(err, qt.IsNil)
+	cellStr := firstRow.GetCell(0).String()
+	t.Logf("cell: %s", cellStr)
+
+	maxRow := sheet.MaxRow
+	_, err = sheet.Row(maxRow)
+	c.Assert(err, qt.IsNil)
+
+	firstRow, err = sheet.Row(0)
+	c.Assert(err, qt.IsNil)
+	cellStr2 := firstRow.GetCell(0).String()
+	t.Logf("cell: %s", cellStr2)
+	c.Assert(cellStr, qt.Equals, cellStr2)
+}


### PR DESCRIPTION
This PR will introduce a bug.
https://github.com/tealeg/xlsx/pull/819/files#diff-736c5868afcf3093a503fb89211daa2dca5ba2b9e2c8fbe5dc105fbbd0e7b963R307
The newly added row index is incorrect, and when reading the data from the row again, it will be empty.