### PR TITLE
fix: Empty cells covering overflowing text of left cell

### DIFF
--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -717,7 +717,7 @@ func (worksheet *xlsxWorksheet) makeXlsxRowFromRow(row *Row, styles *xlsxStyleSh
 		xRow.C = append(xRow.C, xC)
 
 		return nil
-	})
+	}, SkipEmptyCells)
 
 	return xRow, err
 }


### PR DESCRIPTION
Solving following issue:
I am reading a sheet from an existing xlsx file with ValueOnly() and replacing some spaceholder strings with ForEachRow and ForEachCell with SkipEmptyRows and SkipEmptyCells as parameters. Saving the results Save() serializes the xlsx file into file, with empty cells covering my celloverflowing replacements.

The actual code skips only empty rows. This pull request adds the SkipEmptyCells to ForEachCell during serialization and avoids unnecessary cells.