### PR TITLE
Use sync pools for shared string parser

### DIFF
--- a/file.go
+++ b/file.go
@@ -335,7 +335,7 @@ func autoFilterDefinedName(sheet *Sheet, sheetIndex int) (*xlsxDefinedName, erro
 // representing the file in terms of the structure of an XLSX file.
 func (f *File) MakeStreamParts() (map[string]string, error) {
 	var parts map[string]string
-	var refTable *RefTable = NewSharedStringRefTable(10000) // 10000 is arbitrary
+	var refTable *RefTable = NewSharedStringRefTable(DEFAULT_REFTABLE_SIZE)
 	refTable.isWrite = true
 	var workbookRels WorkBookRels = make(WorkBookRels)
 	var err error
@@ -465,7 +465,7 @@ func (f *File) MakeStreamParts() (map[string]string, error) {
 // MarshallParts constructs a map of file name to XML content representing the file
 // in terms of the structure of an XLSX file.
 func (f *File) MarshallParts(zipWriter *zip.Writer) error {
-	var refTable *RefTable = NewSharedStringRefTable(10000) // 10000 is arbitrary
+	var refTable *RefTable = NewSharedStringRefTable(DEFAULT_REFTABLE_SIZE)
 	refTable.isWrite = true
 	var workbookRels WorkBookRels = make(WorkBookRels)
 	var err error
@@ -650,9 +650,10 @@ func (f *File) MarshallParts(zipWriter *zip.Writer) error {
 // Here, value would be set to the raw value of the cell A1 in the
 // first sheet in the XLSX file.
 func (f *File) ToSlice() (output [][][]string, err error) {
-	output = [][][]string{}
+	sheetCount := len(f.Sheets)
+	output = make([][][]string, 0, sheetCount)
 	for _, sheet := range f.Sheets {
-		s := [][]string{}
+		s := make([][]string, 0, sheet.MaxRow)
 		err := sheet.ForEachRow(func(row *Row) error {
 			r := []string{}
 			err := row.ForEachCell(func(cell *Cell) error {

--- a/lib_test.go
+++ b/lib_test.go
@@ -284,6 +284,7 @@ func TestLib(t *testing.T) {
 	// })
 
 	csRunC(c, "ReadRowsFromSheet", func(c *qt.C, constructor CellStoreConstructor) {
+		var err error
 		var sharedstringsXML = bytes.NewBufferString(`
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">
@@ -337,14 +338,12 @@ func TestLib(t *testing.T) {
                footer="0.3"/>
 </worksheet>`)
 		worksheet := new(xlsxWorksheet)
-		err := xml.NewDecoder(sheetxml).Decode(worksheet)
-		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
+		err = xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 		sheet, err := NewSheet("test")
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -433,12 +432,10 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
@@ -486,13 +483,11 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -568,13 +563,11 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -717,12 +710,11 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
+
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -764,13 +756,10 @@ func TestLib(t *testing.T) {
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
 
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
-
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -882,12 +871,11 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
+
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 
@@ -964,12 +952,11 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
+
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -1043,12 +1030,11 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
+
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
 		lt := make(hyperlinkTable)
@@ -1334,13 +1320,10 @@ func TestLib(t *testing.T) {
 		err := xml.NewDecoder(sheetXML).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
 
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
-
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
 
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)
@@ -1433,12 +1416,11 @@ func TestReadRowsFromSheet(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		sst := new(xlsxSST)
-		err = xml.NewDecoder(sharedstringsXML).Decode(sst)
-		c.Assert(err, qt.IsNil)
 		file := new(File)
 		file.cellStoreConstructor = constructor
-		file.referenceTable = MakeSharedStringRefTable(sst)
+		file.referenceTable, err = readSharedStrings(sharedstringsXML)
+		c.Assert(err, qt.IsNil)
+
 		worksheet.mapMergeCells()
 		sheet, err := NewSheetWithCellStore("test", constructor)
 		c.Assert(err, qt.IsNil)

--- a/reftable_test.go
+++ b/reftable_test.go
@@ -75,11 +75,11 @@ func TestCreateNewSharedStringRefTable(t *testing.T) {
 // using xlsx.MakeSharedStringRefTable().
 func TestMakeSharedStringRefTable(t *testing.T) {
 	c := qt.New(t)
-	sst := new(xlsxSST)
 	sharedStringsXML := bytes.NewBufferString(reftabletest_sharedStringsXMLStr)
-	err := xml.NewDecoder(sharedStringsXML).Decode(sst)
+
+	reftable, err := readSharedStrings(sharedStringsXML)
 	c.Assert(err, qt.IsNil)
-	reftable := MakeSharedStringRefTable(sst)
+
 	c.Assert(reftable.Length(), qt.Equals, 5)
 	p, r := reftable.ResolveSharedString(0)
 	c.Assert(p, qt.Equals, "Foo")
@@ -106,11 +106,10 @@ func TestMakeSharedStringRefTable(t *testing.T) {
 // table to a string value using RefTable.ResolveSharedString().
 func TestResolveSharedString(t *testing.T) {
 	c := qt.New(t)
-	sst := new(xlsxSST)
 	sharedStringsXML := bytes.NewBufferString(reftabletest_sharedStringsXMLStr)
-	err := xml.NewDecoder(sharedStringsXML).Decode(sst)
+	reftable, err := readSharedStrings(sharedStringsXML)
 	c.Assert(err, qt.IsNil)
-	reftable := MakeSharedStringRefTable(sst)
+
 	p, r := reftable.ResolveSharedString(0)
 	c.Assert(p, qt.Equals, "Foo")
 	c.Assert(r, qt.IsNil)


### PR DESCRIPTION
This PR save a few megabytes on the shared string table decoding. 