### PR TITLE
Fix hyperlinks in excel

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -376,11 +376,11 @@ func (c *Cell) SetHyperlink(hyperlink string, displayText string, tooltip string
 	h := strings.ToLower(hyperlink)
 	if strings.HasPrefix(h, "http:") || strings.HasPrefix(h, "https://") {
 		c.Hyperlink = Hyperlink{Link: hyperlink}
+		c.Row.Sheet.addRelation(RelationshipTypeHyperlink, hyperlink, RelationshipTargetModeExternal)
 	} else {
-		c.Hyperlink = Hyperlink{Link: hyperlink, Location: hyperlink}
+		c.Hyperlink = Hyperlink{Location: hyperlink}
 	}
 	c.SetString(hyperlink)
-	c.Row.Sheet.addRelation(RelationshipTypeHyperlink, hyperlink, RelationshipTargetModeExternal)
 	if displayText != "" {
 		c.Hyperlink.DisplayString = displayText
 		c.SetString(displayText)

--- a/diskv.go
+++ b/diskv.go
@@ -124,6 +124,9 @@ func (dvr *DiskVRow) readCell(key string) (*Cell, error) {
 	if c.Hyperlink.Link, err = readString(buf); err != nil {
 		return c, err
 	}
+	if c.Hyperlink.Location, err = readString(buf); err != nil {
+		return c, err
+	}
 	if c.Hyperlink.Tooltip, err = readString(buf); err != nil {
 		return c, err
 	}
@@ -196,6 +199,9 @@ func (dvr *DiskVRow) writeCell(c *Cell) error {
 		return err
 	}
 	if err = writeString(&dvr.buf, c.Hyperlink.Link); err != nil {
+		return err
+	}
+	if err = writeString(&dvr.buf, c.Hyperlink.Location); err != nil {
 		return err
 	}
 	if err = writeString(&dvr.buf, c.Hyperlink.Tooltip); err != nil {
@@ -1074,6 +1080,9 @@ func writeCell(buf *bytes.Buffer, c *Cell) error {
 	if err = writeString(buf, c.Hyperlink.Link); err != nil {
 		return err
 	}
+	if err = writeString(buf, c.Hyperlink.Location); err != nil {
+		return err
+	}
 	if err = writeString(buf, c.Hyperlink.Tooltip); err != nil {
 		return err
 	}
@@ -1194,6 +1203,9 @@ func readCell(reader *bytes.Reader) (*Cell, error) {
 		return c, err
 	}
 	if c.Hyperlink.Link, err = readString(reader); err != nil {
+		return c, err
+	}
+	if c.Hyperlink.Location, err = readString(reader); err != nil {
 		return c, err
 	}
 	if c.Hyperlink.Tooltip, err = readString(reader); err != nil {

--- a/diskv_test.go
+++ b/diskv_test.go
@@ -454,6 +454,7 @@ line!`)
 				DisplayString: "displaystring",
 				Link:          "link",
 				Tooltip:       "tooltip",
+				Location:      "location",
 			},
 			num: 1,
 		}

--- a/sheet.go
+++ b/sheet.go
@@ -621,24 +621,34 @@ func (s *Sheet) prepWorksheetFromRows(worksheet *xlsxWorksheet, relations *xlsxW
 					worksheet.Hyperlinks = &xlsxHyperlinks{HyperLinks: []xlsxHyperlink{}}
 				}
 
-				var relId string
-				if relations != nil && relations.Relationships != nil {
-					for _, rel := range relations.Relationships {
-						if rel.Target == cell.Hyperlink.Link {
-							relId = rel.Id
+				if cell.Hyperlink.Location != "" {
+					xlsxLink := xlsxHyperlink{
+						Reference:     cellID,
+						Location:      cell.Hyperlink.Location,
+						DisplayString: cell.Hyperlink.DisplayString,
+						Tooltip:       cell.Hyperlink.Tooltip}
+					worksheet.Hyperlinks.HyperLinks = append(worksheet.Hyperlinks.HyperLinks, xlsxLink)
+				} else {
+					var relId string
+					if relations != nil && relations.Relationships != nil {
+						for _, rel := range relations.Relationships {
+							if rel.Target == cell.Hyperlink.Link {
+								relId = rel.Id
+							}
 						}
+					}
+
+					if relId != "" {
+
+						xlsxLink := xlsxHyperlink{
+							RelationshipId: relId,
+							Reference:      cellID,
+							DisplayString:  cell.Hyperlink.DisplayString,
+							Tooltip:        cell.Hyperlink.Tooltip}
+						worksheet.Hyperlinks.HyperLinks = append(worksheet.Hyperlinks.HyperLinks, xlsxLink)
 					}
 				}
 
-				if relId != "" {
-
-					xlsxLink := xlsxHyperlink{
-						RelationshipId: relId,
-						Reference:      cellID,
-						DisplayString:  cell.Hyperlink.DisplayString,
-						Tooltip:        cell.Hyperlink.Tooltip}
-					worksheet.Hyperlinks.HyperLinks = append(worksheet.Hyperlinks.HyperLinks, xlsxLink)
-				}
 			}
 
 			if cell.HMerge > 0 || cell.VMerge > 0 {
@@ -784,21 +794,30 @@ func (s *Sheet) makeRows(worksheet *xlsxWorksheet, styles *xlsxStyleSheet, refTa
 					worksheet.Hyperlinks = &xlsxHyperlinks{HyperLinks: []xlsxHyperlink{}}
 				}
 
-				var relId string
-				for _, rel := range relations.Relationships {
-					if rel.Target == cell.Hyperlink.Link {
-						relId = rel.Id
-					}
-				}
-
-				if relId != "" {
-
+				if cell.Hyperlink.Location != "" {
 					xlsxLink := xlsxHyperlink{
-						RelationshipId: relId,
-						Reference:      xC.R,
-						DisplayString:  cell.Hyperlink.DisplayString,
-						Tooltip:        cell.Hyperlink.Tooltip}
+						Reference:     xC.R,
+						Location:      cell.Hyperlink.Location,
+						DisplayString: cell.Hyperlink.DisplayString,
+						Tooltip:       cell.Hyperlink.Tooltip}
 					worksheet.Hyperlinks.HyperLinks = append(worksheet.Hyperlinks.HyperLinks, xlsxLink)
+				} else {
+					var relId string
+					for _, rel := range relations.Relationships {
+						if rel.Target == cell.Hyperlink.Link {
+							relId = rel.Id
+						}
+					}
+
+					if relId != "" {
+
+						xlsxLink := xlsxHyperlink{
+							RelationshipId: relId,
+							Reference:      xC.R,
+							DisplayString:  cell.Hyperlink.DisplayString,
+							Tooltip:        cell.Hyperlink.Tooltip}
+						worksheet.Hyperlinks.HyperLinks = append(worksheet.Hyperlinks.HyperLinks, xlsxLink)
+					}
 				}
 			}
 

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -334,6 +334,26 @@ func TestSheet(t *testing.T) {
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetPr filterMode="false"><pageSetUpPr fitToPage="false"/></sheetPr><dimension ref="A1:B1"/><sheetViews><sheetView windowProtection="false" showFormulas="false" showGridLines="true" showRowColHeaders="true" showZeros="true" rightToLeft="false" tabSelected="true" showOutlineSymbols="true" defaultGridColor="true" view="normal" topLeftCell="A1" colorId="64" zoomScale="100" zoomScaleNormal="100" zoomScalePageLayoutView="100" workbookViewId="0"><selection pane="topLeft" activeCell="A1" activeCellId="0" sqref="A1"/></sheetView></sheetViews><sheetFormatPr defaultRowHeight="12.85"/><sheetData><row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row></sheetData></worksheet>`
 		c.Assert(buf.String(), qt.Equals, expectedXLSXSheet)
 	})
+	csRunO(c, "TestMarshalSheetWithInternalLinks", func(c *qt.C, option FileOption) {
+		file := NewFile(option)
+		sheet, _ := file.AddSheet("Sheet1")
+		row := sheet.AddRow()
+		cell := row.AddCell()
+		cell.SetValue("First cell")
+		cell = row.AddCell()
+		cell.SetHyperlink("Sheet1!A1", "Link to first", "")
+		var buf bytes.Buffer
+
+		refTable := NewSharedStringRefTable(2)
+		styles := newXlsxStyleSheet(nil)
+		err := sheet.MarshalSheet(&buf, refTable, styles, nil)
+		c.Assert(err, qt.IsNil)
+
+		expectedXLSXSheet := `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetPr filterMode="false"><pageSetUpPr fitToPage="false"/></sheetPr><dimension ref="A1:B1"/><sheetViews><sheetView windowProtection="false" showFormulas="false" showGridLines="true" showRowColHeaders="true" showZeros="true" rightToLeft="false" tabSelected="true" showOutlineSymbols="true" defaultGridColor="true" view="normal" topLeftCell="A1" colorId="64" zoomScale="100" zoomScaleNormal="100" zoomScalePageLayoutView="100" workbookViewId="0"><selection pane="topLeft" activeCell="A1" activeCellId="0" sqref="A1"/></sheetView></sheetViews><sheetFormatPr defaultRowHeight="12.85"/><sheetData><row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row></sheetData><hyperlinks><hyperlink r:id="" ref="B1" display="Link to first" location="Sheet1!A1"/></hyperlinks></worksheet>`
+		s := buf.String()
+		c.Assert(s, qt.Equals, expectedXLSXSheet)
+	})
 	csRunO(c, "TestSetRowHeightCM", func(c *qt.C, option FileOption) {
 		file := NewFile(option)
 		sheet, _ := file.AddSheet("Sheet1")

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -270,7 +270,7 @@ type xlsxDataValidations struct {
 // The list validation type would more commonly be called "a drop down box."
 type xlsxDataValidation struct {
 	// A boolean value indicating whether the data validation allows the use of empty or blank
-	//entries. 1 means empty entries are OK and do not violate the validation constraints.
+	// entries. 1 means empty entries are OK and do not violate the validation constraints.
 	AllowBlank bool `xml:"allowBlank,attr,omitempty"`
 	// A boolean value indicating whether to display the input prompt message.
 	ShowInputMessage bool `xml:"showInputMessage,attr,omitempty"`
@@ -595,7 +595,7 @@ func emitStructAsXML(v reflect.Value, name, xmlNS string) (xmlwriter.Elem, error
 				Name:  "xmlns",
 				Value: xmlNS,
 			})
-		case "SheetData", "MergeCells", "DataValidations", "AutoFilter":
+		case "SheetData", "MergeCells", "DataValidations", "AutoFilter", "Hyperlinks":
 			// Skip SheetData here, we explicitly generate this in writeXML below
 			// Microsoft Excel considers a mergeCells element before a sheetData element to be
 			// an error and will fail to open the document, so we'll be back with this data
@@ -755,6 +755,15 @@ func (worksheet *xlsxWorksheet) WriteXML(xw *xmlwriter.Writer, s *Sheet, styles 
 		}, SkipEmptyRows),
 		xw.EndElem("sheetData"),
 		func() error {
+			if worksheet.Hyperlinks != nil {
+				hyperlinks, err := emitStructAsXML(reflect.ValueOf(worksheet.Hyperlinks), "hyperlinks", "")
+				if err != nil {
+					return err
+				}
+				if err := xw.Write(hyperlinks); err != nil {
+					return err
+				}
+			}
 			if worksheet.MergeCells != nil {
 				mergeCells, err := emitStructAsXML(reflect.ValueOf(worksheet.MergeCells), "mergeCells", "")
 				if err != nil {

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -755,12 +755,12 @@ func (worksheet *xlsxWorksheet) WriteXML(xw *xmlwriter.Writer, s *Sheet, styles 
 		}, SkipEmptyRows),
 		xw.EndElem("sheetData"),
 		func() error {
-			if worksheet.Hyperlinks != nil {
-				hyperlinks, err := emitStructAsXML(reflect.ValueOf(worksheet.Hyperlinks), "hyperlinks", "")
+			if worksheet.AutoFilter != nil {
+				autoFilter, err := emitStructAsXML(reflect.ValueOf(worksheet.AutoFilter), "autoFilter", "")
 				if err != nil {
 					return err
 				}
-				if err := xw.Write(hyperlinks); err != nil {
+				if err := xw.Write(autoFilter); err != nil {
 					return err
 				}
 			}
@@ -782,12 +782,12 @@ func (worksheet *xlsxWorksheet) WriteXML(xw *xmlwriter.Writer, s *Sheet, styles 
 					return err
 				}
 			}
-			if worksheet.AutoFilter != nil {
-				autoFilter, err := emitStructAsXML(reflect.ValueOf(worksheet.AutoFilter), "autoFilter", "")
+			if worksheet.Hyperlinks != nil {
+				hyperlinks, err := emitStructAsXML(reflect.ValueOf(worksheet.Hyperlinks), "hyperlinks", "")
 				if err != nil {
 					return err
 				}
-				if err := xw.Write(autoFilter); err != nil {
+				if err := xw.Write(hyperlinks); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
The elements inside a worksheet are defined as a sequence, meaning excel expects the elements in a specific order.
Hyperlinks currently are written before sheetData, but must come after sheetData, otherwise it will fail to read them.
Also internal links need to be stored in `location`, which currently get's lost during save.

This fixes #836. Also it adds support for handling internal links in Excel-readable way.