### PR TITLE
Change LocalSheetID to pointer of int

### DIFF
--- a/file.go
+++ b/file.go
@@ -326,7 +326,7 @@ func autoFilterDefinedName(sheet *Sheet, sheetIndex int) (*xlsxDefinedName, erro
 			cellIDStringWithFixed(sheet.AutoFilter.BottomRightCell),
 		),
 		Name:         "_xlnm._FilterDatabase",
-		LocalSheetID: sheetIndex - 1,
+		LocalSheetID: iPtr(sheetIndex - 1),
 		Hidden:       true,
 	}, nil
 }

--- a/file_test.go
+++ b/file_test.go
@@ -967,6 +967,27 @@ func TestFile(t *testing.T) {
 		c.Assert(parts["xl/worksheets/sheet1.xml"], qt.Contains, `<autoFilter ref="A1:D"></autoFilter>`)
 	})
 
+	csRunO(c, "TestSaveFileWithGlobalDefinedNames", func(c *qt.C, option FileOption) {
+		f := NewFile(option)
+		f.AddDefinedName(DefinedName{
+			Name: "global",
+			Data: "MySheet!$A$1",
+		})
+		f.AddDefinedName(DefinedName{
+			Name:         "local",
+			Data:         "MySheet!$A$1",
+			LocalSheetID: iPtr(0),
+		})
+
+		sheet, _ := f.AddSheet("MySheet")
+		row1 := sheet.AddRow()
+		row1.AddCell().SetValue("Cell value")
+
+		parts, err := f.MakeStreamParts()
+		c.Assert(err, qt.IsNil)
+		c.Assert(parts["xl/workbook.xml"], qt.Contains, `<definedNames><definedName name="global">MySheet!$A$1</definedName><definedName name="local" localSheetId="0">MySheet!$A$1</definedName></definedNames>`)
+	})
+
 	// We can save a File as a valid XLSX file at a given path.
 	csRunO(c, "TestSaveFileWithHyperlinks", func(c *qt.C, option FileOption) {
 		tmpPath, err := os.MkdirTemp("", "testsavefilewithhyperlinks")

--- a/utility.go
+++ b/utility.go
@@ -16,3 +16,7 @@ func bPtr(b bool) *bool {
 func u8Ptr(u uint8) *uint8 {
 	return &u
 }
+
+func iPtr(i int) *int {
+	return &i
+}

--- a/xmlWorkbook.go
+++ b/xmlWorkbook.go
@@ -141,7 +141,7 @@ type xlsxDefinedName struct {
 	Help              string `xml:"help,attr,omitempty"`
 	ShortcutKey       string `xml:"shortcutKey,attr,omitempty"`
 	StatusBar         string `xml:"statusBar,attr,omitempty"`
-	LocalSheetID      int    `xml:"localSheetId,attr"`
+	LocalSheetID      *int   `xml:"localSheetId,attr"`
 	FunctionGroupID   int    `xml:"functionGroupId,attr,omitempty"`
 	Function          bool   `xml:"function,attr,omitempty"`
 	Hidden            bool   `xml:"hidden,attr,omitempty"`

--- a/xmlWorkbook_test.go
+++ b/xmlWorkbook_test.go
@@ -48,6 +48,8 @@ func TestUnmarshallWorkbookXML(t *testing.T) {
             <definedName name="monitors" comment="this is the comment"
                          description="give cells a name"
                          localSheetId="0">Sheet1!$A$1533</definedName>
+            <definedName name="global" comment="this is the comment"
+                         description="a global defined name">Sheet1!$A$1533</definedName>
           </definedNames>
           <calcPr calcId="125725"/>
           </workbook>`)
@@ -72,13 +74,20 @@ func TestUnmarshallWorkbookXML(t *testing.T) {
 	c.Assert(sheet.Name, qt.Equals, "Sheet1")
 	c.Assert(sheet.SheetId, qt.Equals, "1")
 	c.Assert(sheet.State, qt.Equals, "visible")
-	c.Assert(workbook.DefinedNames.DefinedName, qt.HasLen, 1)
+	c.Assert(workbook.DefinedNames.DefinedName, qt.HasLen, 2)
 	dname := workbook.DefinedNames.DefinedName[0]
 	c.Assert(dname.Data, qt.Equals, "Sheet1!$A$1533")
-	c.Assert(dname.LocalSheetID, qt.Equals, 0)
+	c.Assert(*dname.LocalSheetID, qt.Equals, 0)
 	c.Assert(dname.Name, qt.Equals, "monitors")
 	c.Assert(dname.Comment, qt.Equals, "this is the comment")
 	c.Assert(dname.Description, qt.Equals, "give cells a name")
+	c.Assert(workbook.CalcPr.CalcId, qt.Equals, "125725")
+	dname2 := workbook.DefinedNames.DefinedName[1]
+	c.Assert(dname2.Data, qt.Equals, "Sheet1!$A$1533")
+	c.Assert(dname2.LocalSheetID, qt.Equals, (*int)(nil))
+	c.Assert(dname2.Name, qt.Equals, "global")
+	c.Assert(dname2.Comment, qt.Equals, "this is the comment")
+	c.Assert(dname2.Description, qt.Equals, "a global defined name")
 	c.Assert(workbook.CalcPr.CalcId, qt.Equals, "125725")
 }
 


### PR DESCRIPTION
Sorry for creating as new PR, but it's still relevant. I can't reopen the closed pr.

Defined names can apply globally (i.e. for every sheet in the document). Global defined names have no LocalSheetID attached to them. LocalSheetID=0 means that the defined name only applies to the first sheet. By changing the type to `*int` the information will be preserved correctly.