### PR TITLE
Handle unsigned ints

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -396,7 +396,7 @@ func (c *Cell) SetValue(n interface{}) {
 	switch t := n.(type) {
 	case time.Time:
 		c.SetDateTime(t)
-	case int, int8, int16, int32, int64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		c.SetNumeric(fmt.Sprintf("%d", n))
 	case float64:
 		// When formatting floats, do not use fmt.Sprintf("%v", n), this will cause numbers below 1e-4 to be printed in

--- a/write.go
+++ b/write.go
@@ -71,8 +71,10 @@ func (r *Row) WriteSlice(e interface{}, cols int) int {
 			}
 		default:
 			switch val.Kind() { // underlying type of slice
-			case reflect.String, reflect.Int, reflect.Int8,
-				reflect.Int16, reflect.Int32, reflect.Int64, reflect.Float64, reflect.Float32:
+			case reflect.String,
+				reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+				reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Float64, reflect.Float32:
 				cell := r.AddCell()
 				cell.SetValue(val.Interface())
 			case reflect.Bool:
@@ -153,8 +155,10 @@ func (r *Row) WriteStruct(e interface{}, cols int) int {
 			}
 		default:
 			switch f.Kind() {
-			case reflect.String, reflect.Int, reflect.Int8,
-				reflect.Int16, reflect.Int32, reflect.Int64, reflect.Float64, reflect.Float32:
+			case reflect.String,
+				reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+				reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Float64, reflect.Float32:
 				cell := r.AddCell()
 				cell.SetValue(f.Interface())
 			case reflect.Bool:


### PR DESCRIPTION
When setting the value of a cell to an unsigned int, it can be handled identically to signed ints.