### PR TITLE
Read relations when parsing a file

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -907,6 +907,14 @@ func TestFile(t *testing.T) {
 		c.Assert(cell1.Value, qt.Equals, "A cell!")
 	})
 
+	csRunO(c, "OpenAndMarshalFileWithHyperlinks", func(c *qt.C, option FileOption) {
+		f, err := OpenFile("./testdocs/file_with_hyperlinks.xlsx", option)
+		c.Assert(err, qt.IsNil)
+		parts, err := f.MakeStreamParts()
+		c.Assert(err, qt.IsNil)
+		c.Assert(parts["xl/worksheets/_rels/sheet1.xml.rels"], qt.Contains, `Target="https://www.google.com/" TargetMode="External"`)
+	})
+
 	csRunO(c, "TestMarshalFileWithHyperlinks", func(c *qt.C, option FileOption) {
 		f := NewFile(option)
 		sheet1, _ := f.AddSheet("MySheet")

--- a/xlsxRelation.go
+++ b/xlsxRelation.go
@@ -1,0 +1,27 @@
+package xlsx
+
+import "encoding/xml"
+
+type RelationshipType string
+
+const (
+	RelationshipTypeHyperlink RelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+)
+
+type RelationshipTargetMode string
+
+const (
+	RelationshipTargetModeExternal RelationshipTargetMode = "External"
+)
+
+type xlsxRels struct {
+	XMLName       xml.Name       `xml:"http://schemas.openxmlformats.org/package/2006/relationships Relationships"`
+	Relationships []xlsxRelation `xml:"Relationship"`
+}
+
+type xlsxRelation struct {
+	Id         string                 `xml:"Id,attr"`
+	Type       RelationshipType       `xml:"Type,attr"`
+	Target     string                 `xml:"Target,attr"`
+	TargetMode RelationshipTargetMode `xml:"TargetMode,attr,omitempty"`
+}

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -11,18 +11,6 @@ import (
 	"github.com/shabbyrobe/xmlwriter"
 )
 
-type RelationshipType string
-
-const (
-	RelationshipTypeHyperlink RelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
-)
-
-type RelationshipTargetMode string
-
-const (
-	RelationshipTargetModeExternal RelationshipTargetMode = "External"
-)
-
 // xlsxWorksheetRels contains xlsxWorksheetRelation
 type xlsxWorksheetRels struct {
 	XMLName       xml.Name                `xml:"http://schemas.openxmlformats.org/package/2006/relationships Relationships"`


### PR DESCRIPTION
Currently, when a file is parsed, existing relations are not parsed and therefore get lost.
This change ensures existing relations will be kept correctly. Fixes a nil-dereference, when trying to open and immediately save/marshal a file, which contains hyperlinks.

Should fix #842.